### PR TITLE
Timeline Refresh Button & URL Parsing

### DIFF
--- a/plural_app/lib/src/common_widgets/app_hyperlinkable_text.dart
+++ b/plural_app/lib/src/common_widgets/app_hyperlinkable_text.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+// Constants
+import 'package:plural_app/src/constants/app_values.dart';
+
+/// A widget for displaying text with clickable hyperlinks.
+///
+/// Hyperlinks should be in the format "(link_title)[link_address]". For example:
+/// "Click here to visit (Google)[https://www.google.com]".
+///
+/// This widget uses regular expressions to identify hyperlinks in the text and
+/// applies the [linkStyle] to them. The [textStyle] is applied to the rest of
+/// the text.
+///
+/// When a hyperlink is tapped, it attempts to launch the provided URL using
+/// the [url_launcher](https://pub.dev/packages/url_launcher) package. If the URL
+/// is successfully launched, it opens the link in the default browser.
+class AppHyperlinkableText extends StatelessWidget {
+  const AppHyperlinkableText({
+    this.linkStyle,
+    this.maxLines,
+    this.mode = LaunchMode.platformDefault,
+    this.overflow = TextOverflow.clip,
+    this.selectionColor,
+    this.softWrap = true,
+    required this.text,
+    this.textStyle,
+    this.textAlign = TextAlign.start,
+    this.webOnlyWindowName = AppURLValues.blank,
+    this.webViewConfiguration = const WebViewConfiguration(),
+  });
+
+  final TextStyle? linkStyle;
+  final int? maxLines;
+  final LaunchMode mode;
+  final TextOverflow overflow;
+  final Color? selectionColor;
+  final bool softWrap;
+  final String text;
+  final TextAlign textAlign;
+  final TextStyle? textStyle;
+  final String? webOnlyWindowName;
+  final WebViewConfiguration webViewConfiguration;
+
+  @override
+  Widget build(BuildContext context) {
+    int currentIndex = 0;
+    List<InlineSpan> parsedText = [];
+
+    // Regular expression to find "[link_title](link_address)"
+    RegExp linkRegex = RegExp(r'\[(.*?)\]\((.*?)\)');
+
+    linkRegex.allMatches(text).forEach((match) {
+      // Add non-link text
+      parsedText.add(TextSpan(
+        text: text.substring(currentIndex, match.start),
+        style: textStyle,
+      ));
+
+      // Prepare gesture recognizer for tapping link
+      var linkGestureRecognizer = TapGestureRecognizer()
+      ..onTap = () async {
+        final linkText = match.group(2) ?? ""; // "[link_address]"
+        final url = Uri.parse(linkText);
+
+        if (await canLaunchUrl(url)) {
+          await launchUrl(
+            url,
+            mode: mode,
+            webOnlyWindowName: webOnlyWindowName,
+            webViewConfiguration: webViewConfiguration,
+          );
+        }
+      };
+
+      // Add link text
+      parsedText.add(
+        TextSpan(
+          text: match.group(1), // "(link_title)"
+          style: linkStyle,
+          recognizer: linkGestureRecognizer
+        )
+      );
+
+      // Update index to be after the (link_title)[link_address] text
+      currentIndex = match.end;
+    });
+
+    // Add remaining non-link text
+    if (currentIndex < text.length) {
+      parsedText.add(
+        TextSpan(
+          text: text.substring(currentIndex),
+          style: textStyle,
+        )
+      );
+    }
+
+    return SelectableText.rich(
+      TextSpan(children: parsedText),
+      maxLines: maxLines,
+      textAlign: textAlign,
+      textWidthBasis: TextWidthBasis.parent,
+    );
+  }
+}

--- a/plural_app/lib/src/common_widgets/app_hyperlinkable_text.dart
+++ b/plural_app/lib/src/common_widgets/app_hyperlinkable_text.dart
@@ -1,30 +1,24 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:plural_app/src/common_widgets/app_snackbars.dart';
+import 'package:plural_app/src/localization/lang_en.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 // Constants
 import 'package:plural_app/src/constants/app_values.dart';
 
-/// A widget for displaying text with clickable hyperlinks.
+/// Source code taken and adapted from
+/// https://github.com/Odinachi/hyperlink/blob/master/lib/src/hyperlink_impl.dart
 ///
-/// Hyperlinks should be in the format "(link_title)[link_address]". For example:
-/// "Click here to visit (Google)[https://www.google.com]".
-///
-/// This widget uses regular expressions to identify hyperlinks in the text and
-/// applies the [linkStyle] to them. The [textStyle] is applied to the rest of
-/// the text.
-///
-/// When a hyperlink is tapped, it attempts to launch the provided URL using
-/// the [url_launcher](https://pub.dev/packages/url_launcher) package. If the URL
-/// is successfully launched, it opens the link in the default browser.
-class AppHyperlinkableText extends StatelessWidget {
+/// _disposeFunctions is implemented as per suggestion of:
+/// https://stackoverflow.com/a/78825170 to avoid memory leaks, as it is stated that
+/// TapGestureRecognizer does not dispose of itself.
+class AppHyperlinkableText extends StatefulWidget {
   const AppHyperlinkableText({
     this.linkStyle,
     this.maxLines,
     this.mode = LaunchMode.platformDefault,
-    this.overflow = TextOverflow.clip,
-    this.selectionColor,
-    this.softWrap = true,
     required this.text,
     this.textStyle,
     this.textAlign = TextAlign.start,
@@ -35,14 +29,32 @@ class AppHyperlinkableText extends StatelessWidget {
   final TextStyle? linkStyle;
   final int? maxLines;
   final LaunchMode mode;
-  final TextOverflow overflow;
-  final Color? selectionColor;
-  final bool softWrap;
   final String text;
   final TextAlign textAlign;
   final TextStyle? textStyle;
   final String? webOnlyWindowName;
   final WebViewConfiguration webViewConfiguration;
+
+  @override
+  State<AppHyperlinkableText> createState() => _AppHyperlinkableTextState();
+}
+
+class _AppHyperlinkableTextState extends State<AppHyperlinkableText> {
+  late List<Function> _disposeFunctions;
+
+  @override
+  void initState() {
+    super.initState();
+    _disposeFunctions = [];
+  }
+
+  @override
+  void dispose() {
+    for (Function disposeFunction in _disposeFunctions) {
+      disposeFunction();
+    }
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -52,11 +64,11 @@ class AppHyperlinkableText extends StatelessWidget {
     // Regular expression to find "[link_title](link_address)"
     RegExp linkRegex = RegExp(r'\[(.*?)\]\((.*?)\)');
 
-    linkRegex.allMatches(text).forEach((match) {
+    linkRegex.allMatches(widget.text).forEach((match) {
       // Add non-link text
       parsedText.add(TextSpan(
-        text: text.substring(currentIndex, match.start),
-        style: textStyle,
+        text: widget.text.substring(currentIndex, match.start),
+        style: widget.textStyle,
       ));
 
       // Prepare gesture recognizer for tapping link
@@ -65,21 +77,41 @@ class AppHyperlinkableText extends StatelessWidget {
         final linkText = match.group(2) ?? ""; // "[link_address]"
         final url = Uri.parse(linkText);
 
-        if (await canLaunchUrl(url)) {
-          await launchUrl(
+        var tapResult = true;
+        try {
+          if (!await launchUrl(
             url,
-            mode: mode,
-            webOnlyWindowName: webOnlyWindowName,
-            webViewConfiguration: webViewConfiguration,
+            mode: widget.mode,
+            webOnlyWindowName: widget.webOnlyWindowName,
+            webViewConfiguration: widget.webViewConfiguration,
+          )) {
+            tapResult = false;
+          }
+        } on PlatformException {
+          tapResult = false;
+        }
+
+        // If the tap did not work, display error Snackbar
+        if (!tapResult && context.mounted) {
+          var snackBar = AppSnackbars.getSnackbar(
+            SnackbarText.urlError,
+            boldMessage: linkText,
+            duration: AppDurations.s9,
+            showCloseIcon: true,
+            snackbarType: SnackbarType.error,
           );
+
+          ScaffoldMessenger.of(context).showSnackBar(snackBar);
         }
       };
+      // Add this TapGestureRecognizer's dispose to _disposeFunctions
+      _disposeFunctions.add(linkGestureRecognizer.dispose);
 
       // Add link text
       parsedText.add(
         TextSpan(
           text: match.group(1), // "(link_title)"
-          style: linkStyle,
+          style: widget.linkStyle,
           recognizer: linkGestureRecognizer
         )
       );
@@ -89,19 +121,19 @@ class AppHyperlinkableText extends StatelessWidget {
     });
 
     // Add remaining non-link text
-    if (currentIndex < text.length) {
+    if (currentIndex < widget.text.length) {
       parsedText.add(
         TextSpan(
-          text: text.substring(currentIndex),
-          style: textStyle,
+          text: widget.text.substring(currentIndex),
+          style: widget.textStyle,
         )
       );
     }
 
     return SelectableText.rich(
       TextSpan(children: parsedText),
-      maxLines: maxLines,
-      textAlign: textAlign,
+      maxLines: widget.maxLines,
+      textAlign: widget.textAlign,
       textWidthBasis: TextWidthBasis.parent,
     );
   }

--- a/plural_app/lib/src/common_widgets/app_snackbars.dart
+++ b/plural_app/lib/src/common_widgets/app_snackbars.dart
@@ -5,30 +5,67 @@ import 'package:plural_app/src/constants/app_sizes.dart';
 import 'package:plural_app/src/constants/app_values.dart';
 import 'package:plural_app/src/constants/themes.dart';
 
+enum SnackbarType {
+  error,
+  success
+}
+
+typedef SnackbarValues = ({
+  Color backgroundColor,
+  Color closeIconColor,
+  IconData icon,
+  Color iconColor,
+  Color textColor,
+});
 class AppSnackbars {
-  static SnackBar getSuccessSnackbar(
+
+  static SnackbarValues _getValues(SnackbarType type) {
+    switch (type) {
+      case SnackbarType.error:
+        return (
+          backgroundColor: AppThemes.snackbarErrorBackgroundColor,
+          closeIconColor: AppThemes.snackbarErrorCloseIconColor,
+          icon: Icons.link_off,
+          iconColor: AppThemes.snackbarErrorIconColor,
+          textColor: AppThemes.snackbarErrorTextColor,
+        );
+      case SnackbarType.success:
+        return (
+          backgroundColor: AppThemes.snackbarSuccessBackgroundColor,
+          closeIconColor: AppThemes.snackbarSuccessCloseIconColor,
+          icon: Icons.check,
+          iconColor: AppThemes.snackbarSuccessIconColor,
+          textColor: AppThemes.snackbarSuccessTextColor,
+        );
+    }
+  }
+
+  static SnackBar getSnackbar(
     String mainMessage,
     {
       String boldMessage = "",
       Duration duration = AppDurations.s3,
-      showCloseIcon = true,
+      bool showCloseIcon = true,
+      required SnackbarType snackbarType,
     }
   ) {
+    var snackbarValues = _getValues(snackbarType);
+
     return SnackBar(
-      backgroundColor: AppThemes.snackbarBackgroundColor,
+      backgroundColor: snackbarValues.backgroundColor,
       behavior: SnackBarBehavior.floating,
       content: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           Icon(
-            Icons.check,
-            color: AppThemes.snackbarIconColor,
+            snackbarValues.icon,
+            color: snackbarValues.iconColor,
           ),
           Expanded(
             child: Text.rich(
               textAlign: TextAlign.center,
               TextSpan(
-                style: TextStyle(color: AppThemes.snackbarTextColor),
+                style: TextStyle(color: snackbarValues.textColor),
                 children: [
                   TextSpan(text: "$mainMessage "),
                   TextSpan(
@@ -45,7 +82,7 @@ class AppSnackbars {
       ),
       duration: duration,
       showCloseIcon: showCloseIcon,
-      closeIconColor: AppThemes.snackbarCloseIconColor,
+      closeIconColor: snackbarValues.closeIconColor,
       width: AppWidths.w600
     );
   }

--- a/plural_app/lib/src/constants/app_values.dart
+++ b/plural_app/lib/src/constants/app_values.dart
@@ -34,3 +34,7 @@ class AppOpacities {
 class AppRotations {
   static const degrees10 = 10/360;
 }
+
+class AppURLValues {
+  static const blank = "_blank";
+}

--- a/plural_app/lib/src/constants/themes.dart
+++ b/plural_app/lib/src/constants/themes.dart
@@ -10,10 +10,15 @@ class AppThemes {
   static Color positiveColor = Color(0xff77BB7A);
 
   // Snackbar
-  static Color snackbarBackgroundColor = Colors.green[400]!;
-  static Color snackbarCloseIconColor = Colors.black;
-  static Color snackbarIconColor = Colors.green[900]!;
-  static Color snackbarTextColor = Colors.black;
+  static Color snackbarSuccessBackgroundColor = Colors.green[400]!;
+  static Color snackbarSuccessCloseIconColor = Colors.black;
+  static Color snackbarSuccessIconColor = Colors.green[900]!;
+  static Color snackbarSuccessTextColor = Colors.black;
+
+  static Color snackbarErrorBackgroundColor = Color(0xffB94B58);
+  static Color snackbarErrorCloseIconColor = Colors.black;
+  static Color snackbarErrorIconColor = Colors.black;
+  static Color snackbarErrorTextColor = Colors.black;
 
   // ColorScheme
   static ColorScheme colorScheme = ColorScheme(

--- a/plural_app/lib/src/features/asks/data/asks_repository.dart
+++ b/plural_app/lib/src/features/asks/data/asks_repository.dart
@@ -3,9 +3,6 @@ import 'dart:developer' as developer;
 import 'package:pocketbase/pocketbase.dart';
 import 'package:get_it/get_it.dart';
 
-// Common Functions
-import 'package:plural_app/src/common_functions/errors.dart';
-
 // Constants
 import 'package:plural_app/src/constants/fields.dart';
 import 'package:plural_app/src/constants/pocketbase.dart';
@@ -21,6 +18,7 @@ import 'package:plural_app/src/localization/lang_en.dart';
 
 // Utils
 import 'package:plural_app/src/utils/app_state.dart';
+import 'package:plural_app/src/utils/exceptions.dart';
 
 /// Iterates over the given [query] to generate a list of [Ask] instances.
 ///

--- a/plural_app/lib/src/features/asks/data/forms.dart
+++ b/plural_app/lib/src/features/asks/data/forms.dart
@@ -33,9 +33,10 @@ Future<void> submitCreate(
       await GetIt.instance<AsksRepository>().create(appForm.fields);
 
     if (isValid && context.mounted) {
-      var snackBar = AppSnackbars.getSuccessSnackbar(
+      var snackBar = AppSnackbars.getSnackbar(
         SnackbarText.createAskSuccess,
-        showCloseIcon: false
+        showCloseIcon: false,
+        snackbarType: SnackbarType.success
       );
 
       // Display Success Snackbar
@@ -68,9 +69,10 @@ Future<void> submitUpdate(
       await GetIt.instance<AsksRepository>().update(appForm.fields);
 
     if (isValid && context.mounted) {
-      var snackBar = AppSnackbars.getSuccessSnackbar(
+      var snackBar = AppSnackbars.getSnackbar(
         SnackbarText.updateAskSuccess,
-        showCloseIcon: false
+        showCloseIcon: false,
+        snackbarType: SnackbarType.success
       );
 
       // Display Success Snackbar
@@ -98,9 +100,10 @@ Future<void> submitDelete(
     await GetIt.instance<AsksRepository>().delete(appForm.fields);
 
   if (isValid && context.mounted) {
-    var snackBar = AppSnackbars.getSuccessSnackbar(
+    var snackBar = AppSnackbars.getSnackbar(
       SnackbarText.deleteAskSuccess,
-      showCloseIcon: false
+      showCloseIcon: false,
+      snackbarType: SnackbarType.success
     );
 
     // Display Success Snackbar

--- a/plural_app/lib/src/features/asks/presentation/creatable_ask_dialog.dart
+++ b/plural_app/lib/src/features/asks/presentation/creatable_ask_dialog.dart
@@ -115,6 +115,10 @@ class _AskDialogCreateFormState extends State<AskDialogCreateForm> {
                       label: AskDialogText.description,
                       maxLength: AppMaxLengths.max400,
                       maxLines: null,
+                      suffixIcon: Tooltip(
+                        message: AskDialogText.urlFormattingText,
+                        child: AppTooltipIcon(dark: false),
+                      ),
                     ),
                     AppTextFormField(
                       appForm: _appForm,

--- a/plural_app/lib/src/features/asks/presentation/editable_ask_dialog.dart
+++ b/plural_app/lib/src/features/asks/presentation/editable_ask_dialog.dart
@@ -139,6 +139,10 @@ class _AskDialogEditFormState extends State<AskDialogEditForm> {
                       label: AskDialogText.description,
                       maxLength: AppMaxLengths.max400,
                       maxLines: null,
+                      suffixIcon: Tooltip(
+                        message: AskDialogText.urlFormattingText,
+                        child: AppTooltipIcon(dark: false),
+                      ),
                     ),
                     AppTextFormField(
                       appForm: _appForm,

--- a/plural_app/lib/src/features/asks/presentation/non_editable_ask_dialog.dart
+++ b/plural_app/lib/src/features/asks/presentation/non_editable_ask_dialog.dart
@@ -131,9 +131,10 @@ class _NonEditableAskHeaderState extends State<NonEditableAskHeader> {
       if (value) {
         await asksRepository.addSponsor(widget.ask.id, currentUserID);
 
-        var snackBar = AppSnackbars.getSuccessSnackbar(
+        var snackBar = AppSnackbars.getSnackbar(
           SnackbarText.askSponsored,
-          showCloseIcon: false
+          showCloseIcon: false,
+          snackbarType: SnackbarType.success
         );
 
         if (context.mounted) ScaffoldMessenger.of(context).showSnackBar(snackBar);

--- a/plural_app/lib/src/features/asks/presentation/non_editable_ask_dialog.dart
+++ b/plural_app/lib/src/features/asks/presentation/non_editable_ask_dialog.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 // Common Widgets
 import 'package:plural_app/src/common_widgets/app_dialog.dart';
 import 'package:plural_app/src/common_widgets/app_dialog_footer.dart';
+import 'package:plural_app/src/common_widgets/app_hyperlinkable_text.dart';
 import 'package:plural_app/src/common_widgets/app_snackbars.dart';
 import 'package:plural_app/src/common_widgets/app_tooltip_icon.dart';
 
@@ -62,7 +63,13 @@ class AskDialogView extends StatelessWidget {
                       right: AppPaddings.p40,
                       bottom: AppPaddings.p40,
                     ),
-                    child: SelectableText(ask.description),
+                    child: AppHyperlinkableText(
+                      text: ask.description,
+                      linkStyle: TextStyle(
+                        color: Theme.of(context).primaryColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
                   ),
                   Divider(
                     color: Theme.of(context).colorScheme.primary,
@@ -74,13 +81,13 @@ class AskDialogView extends StatelessWidget {
                   gapH25,
                   TextColumn(
                     fontWeight: FontWeight.bold,
-                    label: AskDialogText.instructions,
-                    text: ask.instructions,
+                    labelText: AskDialogText.instructions,
+                    bodyText: ask.instructions,
                   ),
                   gapH25,
                   TextColumn(
-                    label: AskDialogText.username,
-                    text: ask.creator.username,
+                    labelText: AskDialogText.username,
+                    bodyText: ask.creator.username,
                   ),
                 ],
               ),
@@ -246,37 +253,44 @@ class BoonColumn extends StatelessWidget {
 class TextColumn extends StatelessWidget {
   const TextColumn({
     this.fontWeight = FontWeight.normal,
-    required this.label,
-    required this.text,
+    required this.labelText,
+    required this.bodyText,
   });
 
   final FontWeight fontWeight;
-  final String label;
-  final String text;
+  final String labelText;
+  final String bodyText;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
+        // Label row
         Row(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
             Text(
-              label,
+              labelText,
               style: TextStyle(color: Theme.of(context).colorScheme.primary)
             ),
           ],
         ),
+        // Body row
         Row(
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
             Flexible(
-              child: SelectableText(
-                text,
-                style: TextStyle(
+              child: AppHyperlinkableText(
+                text: bodyText,
+                linkStyle: TextStyle(
+                  fontSize: AppFontSizes.s16,
+                  fontWeight: fontWeight,
+                  color: Theme.of(context).primaryColor,
+                ),
+                textStyle: TextStyle(
                   fontSize: AppFontSizes.s16,
                   fontWeight: fontWeight
-                )
+                ),
               ),
             ),
           ],

--- a/plural_app/lib/src/features/authentication/data/auth_repository.dart
+++ b/plural_app/lib/src/features/authentication/data/auth_repository.dart
@@ -6,9 +6,6 @@ import 'package:get_it/get_it.dart';
 // Pocketbase
 import 'package:pocketbase/pocketbase.dart';
 
-// Common Functions
-import 'package:plural_app/src/common_functions/errors.dart';
-
 // Constants
 import 'package:plural_app/src/constants/environments.dart';
 import 'package:plural_app/src/constants/fields.dart';
@@ -26,6 +23,7 @@ import "package:plural_app/src/features/gardens/domain/garden.dart";
 
 // Utils
 import 'package:plural_app/src/utils/app_state.dart';
+import 'package:plural_app/src/utils/exceptions.dart';
 import 'package:plural_app/src/utils/service_locator.dart';
 
 /// Attempts to log into the database with the given [usernameOrEmail]

--- a/plural_app/lib/src/features/authentication/data/forms.dart
+++ b/plural_app/lib/src/features/authentication/data/forms.dart
@@ -40,9 +40,10 @@ Future<void> submitUpdateSettings(
       await GetIt.instance<AuthRepository>().updateUserSettings(appForm.fields);
 
     if (isValid && context.mounted) {
-      var snackBar = AppSnackbars.getSuccessSnackbar(
+      var snackBar = AppSnackbars.getSnackbar(
         SnackbarText.updateUserSettingsSuccess,
-        showCloseIcon: false
+        showCloseIcon: false,
+        snackbarType: SnackbarType.success
       );
 
       // Display Success Snackbar
@@ -143,10 +144,11 @@ Future<void> submitSignUp(
       appForm.getValue(fieldName: AppFormFields.tabController).animateTo(
         AuthConstants.logInTabIndex);
 
-      var snackBar = AppSnackbars.getSuccessSnackbar(
+      var snackBar = AppSnackbars.getSnackbar(
         SnackbarText.sentUserVerificationEmail,
         boldMessage: appForm.getValue(fieldName: UserField.email),
         duration: AppDurations.s9,
+        snackbarType: SnackbarType.success
       );
 
       // Display Success Snackbar
@@ -182,10 +184,11 @@ Future<void> submitForgotPassword(
       Navigator.pop(context);
 
       if (isValid) {
-        var snackBar = AppSnackbars.getSuccessSnackbar(
+        var snackBar = AppSnackbars.getSnackbar(
           SnackbarText.sentPasswordResetEmail,
           boldMessage: email,
-          duration: AppDurations.s9
+          duration: AppDurations.s9,
+          snackbarType: SnackbarType.success
         );
 
         // Display Success Snackbar

--- a/plural_app/lib/src/features/gardens/domain/garden.dart
+++ b/plural_app/lib/src/features/gardens/domain/garden.dart
@@ -40,4 +40,7 @@ class Garden {
 
   @override
   int get hashCode => id.hashCode;
+
+  @override
+  String toString() => "Garden(id: $id, name: $name, creator: $creator)";
 }

--- a/plural_app/lib/src/features/gardens/presentation/garden_header.dart
+++ b/plural_app/lib/src/features/gardens/presentation/garden_header.dart
@@ -18,14 +18,27 @@ class GardenHeader extends StatelessWidget {
         Expanded(
           child: Column(
             children: [
-              Text(
-                Provider.of<AppState>(context).currentGarden!.name,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: AppFontSizes.s25,
-                ),
-                textAlign: TextAlign.center,
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  IconButton(
+                    color: Theme.of(context).colorScheme.tertiary,
+                    icon: const Icon(Icons.sync),
+                    onPressed: () {
+                      Provider.of<AppState>(context, listen: false).refresh();
+                    },
+                  ),
+                  gapH5,
+                  Text(
+                    Provider.of<AppState>(context).currentGarden!.name,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: AppFontSizes.s25,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
               ),
               GardenClock(),
             ],

--- a/plural_app/lib/src/localization/lang_en.dart
+++ b/plural_app/lib/src/localization/lang_en.dart
@@ -143,6 +143,8 @@ class SnackbarText {
 
   static const updateAskSuccess = "Ask successfully updated!";
   static const updateUserSettingsSuccess = "Settings updated";
+
+  static const urlError = "Invalid URL:";
 }
 
 class UserSettingsDialogText {

--- a/plural_app/lib/src/localization/lang_en.dart
+++ b/plural_app/lib/src/localization/lang_en.dart
@@ -58,13 +58,17 @@ class AskDialogText {
   static const targetSum = "Target Sum";
   static const tooltipBoon = "The smallest ideal donation amount, "
                               "e.g. \$5 boon for \$20 target sum";
-  static const tooltipInstructions = "How funds can be sent to you";
+  static const tooltipInstructions = "How funds can be sent to you.\n"
+                                      "$urlFormattingText";
   static const type = "Type";
 
   static const unmarkAsSponsored = "Click to unmark as sponsored";
   static const username = "Username";
 
   static const visibleOnTimeline = "Visible on timeline";
+
+  static const urlFormattingText = "Use markdown to format links "
+                                  "e.g. [text](https://www.fakeurl.com)";
 
 }
 

--- a/plural_app/lib/src/utils/app_state.dart
+++ b/plural_app/lib/src/utils/app_state.dart
@@ -79,4 +79,9 @@ class AppState with ChangeNotifier {
   void notifyAllListeners() {
     notifyListeners();
   }
+
+  void refresh() {
+    _timelineAsks.clear();
+    notifyListeners();
+  }
 }

--- a/plural_app/lib/src/utils/exceptions.dart
+++ b/plural_app/lib/src/utils/exceptions.dart
@@ -3,6 +3,8 @@ import 'package:pocketbase/pocketbase.dart';
 const dataKey = "data";
 const messageKey = "message";
 
+class PluralException implements Exception {}
+
 Map<String, String> getErrorsMapFromClientException(ClientException e) {
   Map<String, String> errorsMap = {};
   var innerMap = e.response[dataKey];

--- a/plural_app/linux/flutter/generated_plugin_registrant.cc
+++ b/plural_app/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/plural_app/linux/flutter/generated_plugins.cmake
+++ b/plural_app/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/plural_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/plural_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/plural_app/pubspec.lock
+++ b/plural_app/pubspec.lock
@@ -368,7 +368,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
@@ -597,7 +597,7 @@ packages:
     source: hosted
     version: "3.2.2"
   url_launcher_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"

--- a/plural_app/pubspec.lock
+++ b/plural_app/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
+      sha256: "49b9fb8e7e6722ee93252e05fe83eb08fbb2bd9242a375e7afba921a43acd782"
       url: "https://pub.dev"
     source: hosted
-    version: "80.0.0"
+    version: "81.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
+      sha256: fab62b609c103ef40024384cd90cb44dc13673df7d21702787100b174feccf01
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.4.0"
   args:
     dependency: transitive
     description:
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -77,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
+      sha256: "9086475ef2da7102a0c0a4e37e1e30707e7fb7b6d28c209f559a9c5f8ce42016"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   crypto:
     dependency: transitive
     description:
@@ -174,10 +182,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: "4cdfcc6a178632d1dbb7a728f8e84a1466211354704b9cdc03eee661d3277732"
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "15.0.0"
   http:
     dependency: transitive
     description:
@@ -359,6 +367,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pocketbase:
     dependency: "direct main"
     description:
@@ -387,10 +403,10 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      sha256: "489024f942069c2920c844ee18bb3d467c69e48955a4f32d1677f71be103e310"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   pub_semver:
     dependency: transitive
     description:
@@ -540,6 +556,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "1d0eae19bd7606ef60fe69ef3b312a437a16549476c42321d5dc1506c9ca3bf4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.15"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "7f2022359d4c099eea7df3fdf739f7d3d3b9faf3166fb1dd390775176e0b76cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   validators:
     dependency: "direct main"
     description:
@@ -622,4 +702,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.27.0"

--- a/plural_app/pubspec.yaml
+++ b/plural_app/pubspec.yaml
@@ -18,8 +18,9 @@ dependencies:
   intl: ^0.20.2
   pocketbase: ^0.22.0
   get_it: ^8.0.0
-  go_router: ^14.3.0
+  go_router: ^15.0.0
   validators: ^3.0.0
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:

--- a/plural_app/pubspec.yaml
+++ b/plural_app/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   go_router: ^15.0.0
   validators: ^3.0.0
   url_launcher: ^6.3.1
+  url_launcher_platform_interface: ^2.3.2
+  plugin_platform_interface: ^2.1.8
 
 dev_dependencies:
   flutter_test:

--- a/plural_app/test/common_widgets/app_hyperlinkable_text_test.dart
+++ b/plural_app/test/common_widgets/app_hyperlinkable_text_test.dart
@@ -23,7 +23,7 @@ void main() {
       UrlLauncherPlatform.instance = mockLauncher;
       registerFallbackValue(const LaunchOptions());
 
-      // UrlLauncherPlatform.launchURL
+      // UrlLauncherPlatform.launchURL()
       when(
         () => mockLauncher.launchUrl(any(), any())
       ).thenAnswer(
@@ -71,7 +71,7 @@ void main() {
       UrlLauncherPlatform.instance = mockLauncher;
       registerFallbackValue(const LaunchOptions());
 
-      // UrlLauncherPlatform.launchURL
+      // UrlLauncherPlatform.launchURL()
       when(
         () => mockLauncher.launchUrl(any(), any())
       ).thenThrow(
@@ -119,7 +119,7 @@ void main() {
       UrlLauncherPlatform.instance = mockLauncher;
       registerFallbackValue(const LaunchOptions());
 
-      // UrlLauncherPlatform.launchURL
+      // UrlLauncherPlatform.launchURL()
       when(
         () => mockLauncher.launchUrl(any(), any())
       ).thenAnswer(

--- a/plural_app/test/common_widgets/app_hyperlinkable_text_test.dart
+++ b/plural_app/test/common_widgets/app_hyperlinkable_text_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import "package:mocktail/mocktail.dart";
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+// Common Widgets
+import 'package:plural_app/src/common_widgets/app_hyperlinkable_text.dart';
+
+// Tests
+import '../tester_functions.dart';
+import '../test_mocks.dart';
+
+void main() {
+  /// MockUrlLauncher code taken from: https://stackoverflow.com/a/74128795
+  /// tapTextSpan code taken from: https://stackoverflow.com/a/60247474
+  group("AppHyperlinkableText test", () {
+    testWidgets("launchUrl false", (tester) async {
+      const text = "[Fake Url](https://fakeurl.com)";
+
+      // UrlLauncher Mock
+      var mockLauncher = MockUrlLauncher();
+      UrlLauncherPlatform.instance = mockLauncher;
+      registerFallbackValue(const LaunchOptions());
+
+      // UrlLauncherPlatform.launchURL
+      when(
+        () => mockLauncher.launchUrl(any(), any())
+      ).thenAnswer(
+        (_) async => false
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return AppHyperlinkableText(
+                  text: text,
+                );
+              }
+            ),
+          ),
+      ));
+
+      expect(find.byType(SelectableText), findsOneWidget);
+
+      // Check that markdown has been reformatted
+      expect(find.text(text), findsNothing);
+      expect(find.text("Fake Url"), findsOneWidget);
+
+      // Check snackbar not displayed yet
+      expect(find.byType(SnackBar), findsNothing);
+
+      // Tap the link (found in the TextSpan)
+      tapTextSpan(get<SelectableText>(tester), "Fake Url");
+      await tester.pumpAndSettle();
+
+      // Check that the stubbed method was called
+      verify(() => mockLauncher.launchUrl(any(), any())).called(1);
+
+      // Check snackbar displayed (due to launchUrl returning false)
+      expect(find.byType(SnackBar), findsOneWidget);
+    });
+
+    testWidgets("launchUrl exception", (tester) async {
+      const text = "[Fake Url](https://fakeurl.com)";
+
+      // UrlLauncher Mock
+      var mockLauncher = MockUrlLauncher();
+      UrlLauncherPlatform.instance = mockLauncher;
+      registerFallbackValue(const LaunchOptions());
+
+      // UrlLauncherPlatform.launchURL
+      when(
+        () => mockLauncher.launchUrl(any(), any())
+      ).thenThrow(
+        PlatformException(code: "testcode")
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return AppHyperlinkableText(
+                  text: text,
+                );
+              }
+            ),
+          ),
+      ));
+
+      expect(find.byType(SelectableText), findsOneWidget);
+
+      // Check that markdown has been reformatted
+      expect(find.text(text), findsNothing);
+      expect(find.text("Fake Url"), findsOneWidget);
+
+      // Check snackbar not displayed yet
+      expect(find.byType(SnackBar), findsNothing);
+
+      // Tap the link (found in the TextSpan)
+      tapTextSpan(get<SelectableText>(tester), "Fake Url");
+      await tester.pumpAndSettle();
+
+      // Check that the stubbed method was called
+      verify(() => mockLauncher.launchUrl(any(), any())).called(1);
+
+      // Check snackbar displayed (due to exception)
+      expect(find.byType(SnackBar), findsOneWidget);
+    });
+
+    testWidgets("launchUrl true", (tester) async {
+      const text = "[Fake Url](https://fakeurl.com)";
+
+      // UrlLauncher Mock
+      var mockLauncher = MockUrlLauncher();
+      UrlLauncherPlatform.instance = mockLauncher;
+      registerFallbackValue(const LaunchOptions());
+
+      // UrlLauncherPlatform.launchURL
+      when(
+        () => mockLauncher.launchUrl(any(), any())
+      ).thenAnswer(
+        (_) async => true
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AppHyperlinkableText(
+            text: text,
+          ),
+      ));
+
+      expect(find.byType(SelectableText), findsOneWidget);
+
+      // Check that markdown has been reformatted
+      expect(find.text(text), findsNothing);
+      expect(find.text("Fake Url"), findsOneWidget);
+
+      // Tap the link (found in the TextSpan)
+      tapTextSpan(get<SelectableText>(tester), "Fake Url");
+
+      // Check that the stubbed method was called
+      verify(() => mockLauncher.launchUrl(any(), any())).called(1);
+    });
+  });
+}

--- a/plural_app/test/common_widgets/app_snackbars_test.dart
+++ b/plural_app/test/common_widgets/app_snackbars_test.dart
@@ -16,9 +16,10 @@ void main() {
                   behavior: HitTestBehavior.opaque,
                   child: SizedBox(height: 100.0, width: 100.0,),
                   onTap: () {
-                    final snackBar = AppSnackbars.getSuccessSnackbar(
+                    final snackBar = AppSnackbars.getSnackbar(
                       "Success Message",
-                      showCloseIcon: true
+                      showCloseIcon: true,
+                      snackbarType: SnackbarType.success
                     );
 
                     ScaffoldMessenger.of(context).showSnackBar(snackBar);
@@ -29,7 +30,7 @@ void main() {
           ),
         ));
 
-      // Check text not dispalyed
+      // Check text not displayed (NOTE: trailing space needed)
       expect(find.text("Success Message "), findsNothing);
 
       await tester.tap(find.byType(GestureDetector));
@@ -49,10 +50,11 @@ void main() {
                   behavior: HitTestBehavior.opaque,
                   child: SizedBox(height: 100.0, width: 100.0,),
                   onTap: () {
-                    final snackBar = AppSnackbars.getSuccessSnackbar(
-                      "Success Message",
+                    final snackBar = AppSnackbars.getSnackbar(
+                      "Error Message",
                       boldMessage: "and bold message!",
-                      showCloseIcon: true
+                      showCloseIcon: true,
+                      snackbarType: SnackbarType.error
                     );
 
                     ScaffoldMessenger.of(context).showSnackBar(snackBar);
@@ -64,13 +66,13 @@ void main() {
         ));
 
       // Check text not dispalyed
-      expect(find.text("Success Message and bold message!"), findsNothing);
+      expect(find.text("Error Message and bold message!"), findsNothing);
 
       await tester.tap(find.byType(GestureDetector));
       await tester.pumpAndSettle();
 
       // Check text displayed
-      expect(find.text("Success Message and bold message!"), findsOneWidget);
+      expect(find.text("Error Message and bold message!"), findsOneWidget);
     });
 
     testWidgets("SnackBar showCloseIcon true", (tester) async {
@@ -83,9 +85,10 @@ void main() {
                   behavior: HitTestBehavior.opaque,
                   child: SizedBox(height: 100.0, width: 100.0,),
                   onTap: () {
-                    final snackBar = AppSnackbars.getSuccessSnackbar(
+                    final snackBar = AppSnackbars.getSnackbar(
                       "Success Message",
-                      showCloseIcon: true
+                      showCloseIcon: true,
+                      snackbarType: SnackbarType.success
                     );
 
                     ScaffoldMessenger.of(context).showSnackBar(snackBar);
@@ -116,9 +119,10 @@ void main() {
                   behavior: HitTestBehavior.opaque,
                   child: SizedBox(height: 100.0, width: 100.0,),
                   onTap: () {
-                    final snackBar = AppSnackbars.getSuccessSnackbar(
-                      "Success Message",
-                      showCloseIcon: false
+                    final snackBar = AppSnackbars.getSnackbar(
+                      "Error Message",
+                      showCloseIcon: false,
+                      snackbarType: SnackbarType.error
                     );
 
                     ScaffoldMessenger.of(context).showSnackBar(snackBar);

--- a/plural_app/test/features/gardens/presentation/garden_header_test.dart
+++ b/plural_app/test/features/gardens/presentation/garden_header_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import "package:mocktail/mocktail.dart";
 import 'package:provider/provider.dart';
 
-
-// Asks
+// Gardens
 import 'package:plural_app/src/features/gardens/presentation/garden_clock.dart';
 import 'package:plural_app/src/features/gardens/presentation/garden_header.dart';
 
@@ -12,6 +12,7 @@ import 'package:plural_app/src/utils/app_state.dart';
 
 // Tests
 import '../../../test_context.dart';
+import '../../../test_mocks.dart';
 
 void main() {
   group("GardenClock test", () {
@@ -30,9 +31,48 @@ void main() {
           )
         ));
 
-      // Check text widget is rendered; GardenClock is rendered
+      // Check text widget is rendered; GardenClock is rendered;
+      // refresh button is rendered
       expect(find.text(tc.garden.name), findsOneWidget);
       expect(find.byType(GardenClock), findsOneWidget);
+      expect(find.byType(IconButton), findsOneWidget);
+    });
+
+    testWidgets("refresh", (tester) async {
+      final tc = TestContext();
+
+      // final appState = AppState()
+      //                   ..currentGarden = tc.garden;
+      final mockAppState = MockAppState();
+
+      // AppState.currentGarden()
+      when(
+        () => mockAppState.currentGarden
+      ).thenAnswer(
+        (_) => tc.garden
+      );
+      // AppState.refresh()
+      when(
+        () => mockAppState.refresh()
+      ).thenAnswer(
+        (_) => {}
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<AppState>.value(
+            value: mockAppState,
+            child: Scaffold(
+              body: GardenHeader(),
+            )
+          )
+        ));
+
+      // Tap on the refresh button
+      await tester.tap(find.byType(IconButton));
+      tester.pumpAndSettle();
+
+      verify(() => mockAppState.refresh()).called(1);
     });
   });
 }

--- a/plural_app/test/test_context.dart
+++ b/plural_app/test/test_context.dart
@@ -1,9 +1,6 @@
 import 'package:intl/intl.dart';
 import 'package:pocketbase/pocketbase.dart';
 
-// Common Functions
-import 'package:plural_app/src/common_functions/errors.dart';
-
 // Constants
 import 'package:plural_app/src/constants/fields.dart';
 import 'package:plural_app/src/constants/formats.dart';
@@ -19,6 +16,9 @@ import 'package:plural_app/src/features/authentication/domain/app_user_settings.
 
 // Gardens
 import 'package:plural_app/src/features/gardens/domain/garden.dart';
+
+// Utils
+import 'package:plural_app/src/utils/exceptions.dart';
 
 class TestContext {
   late Ask ask;

--- a/plural_app/test/test_mocks.dart
+++ b/plural_app/test/test_mocks.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import "package:mocktail/mocktail.dart";
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pocketbase/pocketbase.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 // Asks
 import 'package:plural_app/src/features/asks/data/asks_repository.dart';
@@ -23,3 +25,5 @@ class MockGardensRepository extends Mock implements GardensRepository {}
 class MockGoRouter extends Mock implements GoRouter {}
 class MockPocketBase extends Mock implements PocketBase {}
 class MockRecordService extends Mock implements RecordService {}
+class MockUrlLauncher extends Mock with MockPlatformInterfaceMixin
+  implements UrlLauncherPlatform {}

--- a/plural_app/test/test_mocks.dart
+++ b/plural_app/test/test_mocks.dart
@@ -16,8 +16,10 @@ import 'package:plural_app/src/features/gardens/data/gardens_repository.dart';
 
 // Utils
 import 'package:plural_app/src/utils/app_dialog_router.dart';
+import 'package:plural_app/src/utils/app_state.dart';
 
 class MockAppDialogRouter extends Mock implements AppDialogRouter {}
+class MockAppState extends Mock implements AppState {}
 class MockAsksRepository extends Mock implements AsksRepository {}
 class MockAuthRepository extends Mock implements AuthRepository {}
 class MockBuildContext extends Mock implements BuildContext {}

--- a/plural_app/test/tester_functions.dart
+++ b/plural_app/test/tester_functions.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -24,4 +25,24 @@ T getLast<T extends Widget>(WidgetTester tester) {
 
 TextEditingController textFieldController(WidgetTester tester) {
   return get<TextField>(tester).controller!;
+}
+
+bool findTextAndTap(InlineSpan visitor, String text) {
+  if (visitor is TextSpan && visitor.text == text) {
+    (visitor.recognizer as TapGestureRecognizer).onTap!();
+    // Return false if successful match
+    return false;
+  }
+
+  return true;
+}
+
+/// Used to parse through a list of InlineSpan in a SelectableText
+/// and to tap on any string matching the given [text] value.
+bool tapTextSpan(SelectableText selectableText, String text) {
+  final isTapped = !selectableText.textSpan!.visitChildren(
+    (visitor) => findTextAndTap(visitor, text),
+  );
+
+  return isTapped;
 }

--- a/plural_app/test/utils/exceptions_test.dart
+++ b/plural_app/test/utils/exceptions_test.dart
@@ -1,13 +1,15 @@
 import 'package:pocketbase/pocketbase.dart' show ClientException;
-import 'package:plural_app/src/common_functions/errors.dart' as errors;
 
 import 'package:test/test.dart';
 
 // Constants
 import 'package:plural_app/src/constants/fields.dart';
 
+// Utils
+import 'package:plural_app/src/utils/exceptions.dart' as errors;
+
 void main() {
-  group("Errors test", () {
+  group("Exceptions test", () {
     test("getErrorsMapFromClientException", () {
       var exception = ClientException(
         url: Uri(),

--- a/plural_app/windows/flutter/generated_plugin_registrant.cc
+++ b/plural_app/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/plural_app/windows/flutter/generated_plugins.cmake
+++ b/plural_app/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Changes:
- New widget - AppHyperlinkableText - to handle text parsing and converting markdown to clickable URL.
- New button in Garden Header to allow for manual refresh of the Garden Timeline.

Closes #27 
Closes #19 