### PR TITLE
Add permission groups and UnauthorizedPage widget

### DIFF
--- a/plural_app/integration_test/app_test.dart
+++ b/plural_app/integration_test/app_test.dart
@@ -28,7 +28,7 @@ import 'package:plural_app/src/features/authentication/presentation/log_in_passw
 
 // Gardens
 import 'package:plural_app/src/features/gardens/presentation/garden_timeline_tile.dart';
-import 'package:plural_app/src/features/gardens/presentation/listed_garden_tile.dart';
+import 'package:plural_app/src/features/gardens/presentation/landing_page_listed_garden_tile.dart';
 
 // Tests
 import '../test/test_context.dart';

--- a/plural_app/lib/src/constants/app_sizes.dart
+++ b/plural_app/lib/src/constants/app_sizes.dart
@@ -67,6 +67,7 @@ class AppIconSizes {
   static const s30 = 30.0;
   static const s35 = 35.0;
   static const s40 = 40.0;
+  static const s110 = 110.0;
 }
 
 class AppIndents {

--- a/plural_app/lib/src/constants/query_parameters.dart
+++ b/plural_app/lib/src/constants/query_parameters.dart
@@ -1,3 +1,4 @@
 class QueryParameters {
   static const exitedGardenID = "exitedGardenID";
+  static const previousRoute = "previousRoute";
 }

--- a/plural_app/lib/src/constants/routes.dart
+++ b/plural_app/lib/src/constants/routes.dart
@@ -2,4 +2,5 @@ class Routes {
   static const garden = "/";
   static const landing = "/landing";
   static const signIn = "/signin";
+  static const unauthorized = "/unauthorized";
 }

--- a/plural_app/lib/src/features/authentication/data/auth_api.dart
+++ b/plural_app/lib/src/features/authentication/data/auth_api.dart
@@ -118,14 +118,6 @@ Future<void> deleteCurrentUserSettings() async {
   await GetIt.instance<UserSettingsRepository>().delete(id: currentUserSettings.id);
 }
 
-/// Returns the [AppUserGardenRole] enum that corresponds to [roleString].
-AppUserGardenRole getUserGardenRoleFromString(String roleString) {
-  return AppUserGardenRole.values.firstWhere(
-    (a) => a.name == roleString,
-    orElse: () => AppUserGardenRole.member
-  );
-}
-
 /// Queries on the [UserGardenRecord] collection to retrieve all [User]s
 /// with the same [Garden] as the currentGarden.
 ///
@@ -174,6 +166,41 @@ Future<AppUser> getUserByID(String userID) async {
   return AppUser.fromJson(query.toJson());
 }
 
+/// Returns a list of AppUserGardenPermissions associated with the given [role].
+List<AppUserGardenPermission> getUserGardenPermissionGroup(AppUserGardenRole role) {
+  final List<AppUserGardenPermission> group = [];
+
+  // Member permissions
+  if (role.priority >= AppUserGardenRole.member.priority) {
+    group.addAll([
+      AppUserGardenPermission.createAsks
+    ]);
+  }
+
+  // Moderator permissions
+  if (role.priority >= AppUserGardenRole.moderator.priority) {
+    group.addAll([
+      AppUserGardenPermission.changeGardenName,
+      AppUserGardenPermission.changeMemberRoles,
+      AppUserGardenPermission.createAsks,
+      AppUserGardenPermission.createInvitations,
+      AppUserGardenPermission.deleteMemberAsks,
+      AppUserGardenPermission.enterModView,
+      AppUserGardenPermission.kickMembers,
+      AppUserGardenPermission.viewAuditLog,
+    ]);
+  }
+
+  // Owner permissions
+  if (role.priority >= AppUserGardenRole.owner.priority) {
+    group.addAll([
+      AppUserGardenPermission.deleteGarden,
+    ]);
+  }
+
+  return group;
+}
+
 /// Queries on the [UserGardenRecord] collection, to retrieve a UserGardenRecord
 /// corresponding to [userID] and [gardenID].
 Future<AppUserGardenRecord?> getUserGardenRecord({
@@ -197,6 +224,14 @@ Future<AppUserGardenRecord?> getUserGardenRecord({
   final user = await getUserByID(userID);
 
   return AppUserGardenRecord.fromJson(record, user, garden);
+}
+
+/// Returns the [AppUserGardenRole] enum that corresponds to [roleString].
+AppUserGardenRole getUserGardenRoleFromString(String roleString) {
+  return AppUserGardenRole.values.firstWhere(
+    (a) => a.name == roleString,
+    orElse: () => AppUserGardenRole.member
+  );
 }
 
 /// Attempts to log in to the database with [usernameOrEmail]

--- a/plural_app/lib/src/features/authentication/domain/app_user_garden_record.dart
+++ b/plural_app/lib/src/features/authentication/domain/app_user_garden_record.dart
@@ -10,9 +10,27 @@ import 'package:plural_app/src/features/authentication/domain/app_user.dart';
 import 'package:plural_app/src/features/gardens/domain/garden.dart';
 
 enum AppUserGardenRole {
-  member,
-  mod,
-  owner,
+  member(priority: 0),
+  moderator(priority: 1),
+  owner(priority: 2);
+
+  const AppUserGardenRole({
+    required this.priority
+  });
+
+  final int priority;
+}
+
+enum AppUserGardenPermission {
+  changeGardenName,
+  changeMemberRoles,
+  createAsks,
+  createInvitations,
+  deleteGarden,
+  deleteMemberAsks,
+  enterModView,
+  kickMembers,
+  viewAuditLog,
 }
 
 class AppUserGardenRecord {

--- a/plural_app/lib/src/features/authentication/presentation/sign_in_page.dart
+++ b/plural_app/lib/src/features/authentication/presentation/sign_in_page.dart
@@ -3,6 +3,8 @@ import 'package:pocketbase/pocketbase.dart';
 
 // Common Classes
 import 'package:plural_app/src/utils/app_form.dart';
+
+// Common Widgets
 import 'package:plural_app/src/common_widgets/app_logo.dart';
 
 // Constants

--- a/plural_app/lib/src/features/authentication/presentation/unauthorized_page.dart
+++ b/plural_app/lib/src/features/authentication/presentation/unauthorized_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+// Common Widgets
+import 'package:plural_app/src/common_widgets/app_logo.dart';
+import 'package:plural_app/src/common_widgets/app_text_button.dart';
+
+// Constants
+import 'package:plural_app/src/constants/app_sizes.dart';
+import 'package:plural_app/src/constants/routes.dart';
+
+// Localization
+import 'package:plural_app/src/localization/lang_en.dart';
+
+class UnauthorizedPage extends StatelessWidget {
+  const UnauthorizedPage({
+    this.previousRoute,
+  });
+
+  final String? previousRoute;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.block,
+              color: Theme.of(context).colorScheme.primaryContainer,
+              size: AppIconSizes.s110,
+            ),
+            Text(
+              UnauthorizedPageText.messageHeader,
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            gapH15,
+            Text(
+              UnauthorizedPageText.messageBody,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            gapH30,
+            AppTextButton(
+              callback: GoRouter.of(context).go,
+              fontSize: AppFontSizes.s20,
+              label: UnauthorizedPageText.buttonText,
+              positionalArguments: [previousRoute ?? Routes.signIn],
+            )
+          ],
+        )
+      ),
+      bottomSheet: MediaQuery.sizeOf(context).height > AppHeights.h800 ?
+        AppLogo()
+        : null,
+    );
+  }
+}

--- a/plural_app/lib/src/features/gardens/presentation/landing_page_gardens_tab.dart
+++ b/plural_app/lib/src/features/gardens/presentation/landing_page_gardens_tab.dart
@@ -7,7 +7,7 @@ import 'package:plural_app/src/constants/app_sizes.dart';
 // Gardens
 import 'package:plural_app/src/features/gardens/data/gardens_api.dart';
 import 'package:plural_app/src/features/gardens/domain/garden.dart';
-import 'package:plural_app/src/features/gardens/presentation/listed_garden_tile.dart';
+import 'package:plural_app/src/features/gardens/presentation/landing_page_listed_garden_tile.dart';
 
 // Localization
 import 'package:plural_app/src/localization/lang_en.dart';

--- a/plural_app/lib/src/features/gardens/presentation/landing_page_listed_garden_tile.dart
+++ b/plural_app/lib/src/features/gardens/presentation/landing_page_listed_garden_tile.dart
@@ -10,34 +10,6 @@ import 'package:plural_app/src/features/gardens/domain/garden.dart';
 // Utils
 import 'package:plural_app/src/utils/app_state.dart';
 
-class ListedGardenTile extends StatelessWidget {
-  const ListedGardenTile({
-    required this.garden,
-  });
-
-  final Garden garden;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      elevation: AppElevations.e7,
-      child: ListTile(
-        tileColor: Theme.of(context).colorScheme.secondary,
-        title: Text(
-          garden.name,
-          style: TextStyle(fontWeight: FontWeight.w500),
-        ),
-        trailing: const Icon(Icons.arrow_forward_ios),
-        onTap: () {
-          // Update AppState.currentGarden (should also rebuild Garden Timeline via notifyListeners())
-          GetIt.instance<AppState>().currentGarden = garden;
-          Navigator.pop(context);
-        }
-      ),
-    );
-  }
-}
-
 class LandingPageListedGardenTile extends StatelessWidget {
   const LandingPageListedGardenTile({
     required this.garden,

--- a/plural_app/lib/src/localization/lang_en.dart
+++ b/plural_app/lib/src/localization/lang_en.dart
@@ -174,6 +174,15 @@ class SnackbarText {
   static const urlError = "Invalid URL:";
 }
 
+class UnauthorizedPageText {
+  static const buttonText = "Return";
+
+  static const messageBody = ""
+    "You do not have the necessary permissions to access this page.";
+  static const messageHeader = "Unauthorized Access";
+
+}
+
 class UserSettingsDialogText {
   static const cancelConfirmExitGarden = "Cancel";
   static const confirmExitGarden = "Are you sure?";

--- a/plural_app/lib/src/routing/app_router.dart
+++ b/plural_app/lib/src/routing/app_router.dart
@@ -7,6 +7,7 @@ import 'package:plural_app/src/constants/routes.dart';
 
 // Auth
 import 'package:plural_app/src/features/authentication/presentation/sign_in_page.dart';
+import 'package:plural_app/src/features/authentication/presentation/unauthorized_page.dart';
 
 // Garden
 import 'package:plural_app/src/features/gardens/presentation/garden_page.dart';
@@ -32,7 +33,13 @@ class AppRouter {
           builder: (_, __) => SignInPage(
             database: database
           ),
-        )
+        ),
+        GoRoute(
+          path: Routes.unauthorized,
+          builder: (_, state) => UnauthorizedPage(
+            previousRoute: state.uri.queryParameters[QueryParameters.previousRoute],
+          )
+        ),
       ]
     );
   }

--- a/plural_app/test/features/authentication/data/auth_api_test.dart
+++ b/plural_app/test/features/authentication/data/auth_api_test.dart
@@ -254,15 +254,6 @@ void main() {
 
     tearDown(() => GetIt.instance.reset());
 
-    test("getUserGardenRoleFromString", () async {
-      expect(getUserGardenRoleFromString("member"), AppUserGardenRole.member);
-      expect(getUserGardenRoleFromString("mod"), AppUserGardenRole.mod);
-      expect(getUserGardenRoleFromString("owner"), AppUserGardenRole.owner);
-
-      // Check that fallback value is member
-      expect(getUserGardenRoleFromString("invalidValue"), AppUserGardenRole.member);
-    });
-
     test("getCurrentGardenUsers", () async {
       final tc = TestContext();
 
@@ -363,6 +354,47 @@ void main() {
 
     tearDown(() => GetIt.instance.reset());
 
+    test("getUserGardenPermissionGroup", () async {
+      // Member permissions
+      expect(
+        getUserGardenPermissionGroup(AppUserGardenRole.member),
+        [AppUserGardenPermission.createAsks]
+      );
+
+      // Moderator permissions
+      expect(
+        getUserGardenPermissionGroup(AppUserGardenRole.moderator),
+        [
+          AppUserGardenPermission.createAsks,
+          AppUserGardenPermission.changeGardenName,
+          AppUserGardenPermission.changeMemberRoles,
+          AppUserGardenPermission.createAsks,
+          AppUserGardenPermission.createInvitations,
+          AppUserGardenPermission.deleteMemberAsks,
+          AppUserGardenPermission.enterModView,
+          AppUserGardenPermission.kickMembers,
+          AppUserGardenPermission.viewAuditLog,
+        ]
+      );
+
+      // Owner permissions
+      expect(
+        getUserGardenPermissionGroup(AppUserGardenRole.owner),
+        [
+          AppUserGardenPermission.createAsks,
+          AppUserGardenPermission.changeGardenName,
+          AppUserGardenPermission.changeMemberRoles,
+          AppUserGardenPermission.createAsks,
+          AppUserGardenPermission.createInvitations,
+          AppUserGardenPermission.deleteMemberAsks,
+          AppUserGardenPermission.enterModView,
+          AppUserGardenPermission.kickMembers,
+          AppUserGardenPermission.viewAuditLog,
+          AppUserGardenPermission.deleteGarden,
+        ]
+      );
+    });
+
     test("getUserGardenRecord", () async {
       final tc = TestContext();
 
@@ -446,6 +478,15 @@ void main() {
     });
 
     tearDown(() => GetIt.instance.reset());
+
+    test("getUserGardenRoleFromString", () async {
+      expect(getUserGardenRoleFromString("member"), AppUserGardenRole.member);
+      expect(getUserGardenRoleFromString("moderator"), AppUserGardenRole.moderator);
+      expect(getUserGardenRoleFromString("owner"), AppUserGardenRole.owner);
+
+      // Check that fallback value is member
+      expect(getUserGardenRoleFromString("invalidValue"), AppUserGardenRole.member);
+    });
 
     test("login", () async {
       final tc = TestContext();

--- a/plural_app/test/features/authentication/presentation/sign_in_page_test.dart
+++ b/plural_app/test/features/authentication/presentation/sign_in_page_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// Common Widgets
+import 'package:plural_app/src/common_widgets/app_logo.dart';
+
 // Auth
 import 'package:plural_app/src/features/authentication/presentation/log_in_tab.dart';
 import 'package:plural_app/src/features/authentication/presentation/sign_in_page.dart';
@@ -37,6 +40,28 @@ void main() {
       // Check only SignUp tab rendered fully; LogIn tab not rendered
       expect(find.byType(LogInTab), findsNothing);
       expect(find.byType(SignUpTab), findsOneWidget);
+    });
+
+    testWidgets("appLogo", (tester) async {
+      final dpi = tester.view.devicePixelRatio;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SignInPage()
+          )
+        )
+      );
+
+      // height > 800
+      tester.view.physicalSize = Size(tester.view.physicalSize.width, 1200 * dpi);
+      await tester.pumpAndSettle();
+      expect(find.byType(AppLogo), findsOneWidget);
+
+      // height < 800
+      tester.view.physicalSize = Size(tester.view.physicalSize.width, 700 * dpi);
+      await tester.pumpAndSettle();
+      expect(find.byType(AppLogo), findsNothing);
     });
   });
 }

--- a/plural_app/test/features/authentication/presentation/unauthorized_page_test.dart
+++ b/plural_app/test/features/authentication/presentation/unauthorized_page_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:plural_app/src/common_widgets/app_logo.dart';
+
+// Common Widgets
+import 'package:plural_app/src/common_widgets/app_text_button.dart';
+import 'package:plural_app/src/constants/routes.dart';
+
+// Auth
+import 'package:plural_app/src/features/authentication/presentation/unauthorized_page.dart';
+
+// Localization
+import 'package:plural_app/src/localization/lang_en.dart';
+
+void main() {
+  group("UnauthorizedPage test", () {
+    testWidgets("null previousRoute", (tester) async {
+      final testRouter = GoRouter(
+        initialLocation: Routes.unauthorized,
+        routes: [
+          GoRoute(
+            path: Routes.signIn,
+            builder: (_, __) => SizedBox(child: Text("testSignInReroute"),)
+          ),
+          GoRoute(
+            path: Routes.unauthorized,
+            builder: (_, __) => Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  return UnauthorizedPage();
+                }
+              )
+            )
+          )
+        ]
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: testRouter,
+        )
+      );
+
+      expect(find.text(UnauthorizedPageText.messageHeader), findsOneWidget);
+      expect(find.text(UnauthorizedPageText.messageBody), findsOneWidget);
+
+      final appTextButton = find.byType(AppTextButton);
+      expect(appTextButton, findsOneWidget);
+
+      expect(find.text("testSignInReroute"), findsNothing);
+
+      await tester.tap(appTextButton);
+      await tester.pumpAndSettle();
+
+      expect(find.text("testSignInReroute"), findsOneWidget);
+    });
+
+    testWidgets("non null previousRoute", (tester) async {
+      final testRouter = GoRouter(
+        initialLocation: Routes.unauthorized,
+        routes: [
+          GoRoute(
+            path: Routes.signIn,
+            builder: (_, __) => SizedBox(child: Text("testSignInReroute"),)
+          ),
+          GoRoute(
+            path: "/test",
+            builder: (_, __) => SizedBox(child: Text("testTestReroute"),)
+          ),
+          GoRoute(
+            path: Routes.unauthorized,
+            builder: (_, __) => Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  return UnauthorizedPage(previousRoute: "/test",);
+                }
+              )
+            )
+          )
+        ]
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: testRouter,
+        )
+      );
+
+      expect(find.text(UnauthorizedPageText.messageHeader), findsOneWidget);
+      expect(find.text(UnauthorizedPageText.messageBody), findsOneWidget);
+
+      final appTextButton = find.byType(AppTextButton);
+      expect(appTextButton, findsOneWidget);
+
+      expect(find.text("testSignInReroute"), findsNothing);
+      expect(find.text("testTestReroute"), findsNothing);
+
+      await tester.tap(appTextButton);
+      await tester.pumpAndSettle();
+
+      // Test redirected to /test and not to /signin
+      expect(find.text("testSignInReroute"), findsNothing);
+      expect(find.text("testTestReroute"), findsOneWidget);
+    });
+
+    testWidgets("appLogo", (tester) async {
+      final dpi = tester.view.devicePixelRatio;
+
+      final testRouter = GoRouter(
+        initialLocation: Routes.unauthorized,
+        routes: [
+          GoRoute(
+            path: Routes.signIn,
+            builder: (_, __) => SizedBox(child: Text("testSignInReroute"),)
+          ),
+          GoRoute(
+            path: Routes.unauthorized,
+            builder: (_, __) => Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  return UnauthorizedPage();
+                }
+              )
+            )
+          )
+        ]
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: testRouter,
+        )
+      );
+
+      // height > 800
+      tester.view.physicalSize = Size(tester.view.physicalSize.width, 1200 * dpi);
+      await tester.pumpAndSettle();
+      expect(find.byType(AppLogo), findsOneWidget);
+
+      // height < 800
+      tester.view.physicalSize = Size(tester.view.physicalSize.width, 700 * dpi);
+      await tester.pumpAndSettle();
+      expect(find.byType(AppLogo), findsNothing);
+    });
+  });
+}

--- a/plural_app/test/features/gardens/presentation/landing_page_gardens_tab_test.dart
+++ b/plural_app/test/features/gardens/presentation/landing_page_gardens_tab_test.dart
@@ -14,7 +14,7 @@ import 'package:plural_app/src/features/authentication/data/users_repository.dar
 // Gardens
 import 'package:plural_app/src/features/gardens/data/gardens_repository.dart';
 import 'package:plural_app/src/features/gardens/presentation/landing_page_gardens_tab.dart';
-import 'package:plural_app/src/features/gardens/presentation/listed_garden_tile.dart';
+import 'package:plural_app/src/features/gardens/presentation/landing_page_listed_garden_tile.dart';
 
 // Utils
 import 'package:plural_app/src/utils/app_state.dart';

--- a/plural_app/test/features/gardens/presentation/listed_garden_tile_test.dart
+++ b/plural_app/test/features/gardens/presentation/listed_garden_tile_test.dart
@@ -18,7 +18,7 @@ import 'package:plural_app/src/features/authentication/data/users_repository.dar
 
 // Gardens
 import 'package:plural_app/src/features/gardens/data/gardens_repository.dart';
-import 'package:plural_app/src/features/gardens/presentation/listed_garden_tile.dart';
+import 'package:plural_app/src/features/gardens/presentation/landing_page_listed_garden_tile.dart';
 
 // Utils
 import 'package:plural_app/src/utils/app_state.dart';
@@ -29,85 +29,6 @@ import '../../../test_mocks.dart';
 
 void main() {
   group("ListedGardenTile test", () {
-    testWidgets("ListedGardenTile", (tester) async {
-      final tc = TestContext();
-
-      final appState = AppState()
-                        ..currentGarden = null;
-
-      final getIt = GetIt.instance;
-      final mockAsksRepository = MockAsksRepository();
-      final mockGardensRepository = MockGardensRepository();
-      final mockUsersRepository = MockUsersRepository();
-      getIt.registerLazySingleton<AsksRepository>(() => mockAsksRepository);
-      getIt.registerLazySingleton<AppState>(() => appState);
-      getIt.registerLazySingleton<GardensRepository>(() => mockGardensRepository);
-      getIt.registerLazySingleton<UsersRepository>(() => mockUsersRepository);
-
-      // AsksRepository.unsubscribe()
-      when(
-        () => mockAsksRepository.unsubscribe()
-      ).thenAnswer(
-        (_) async => {}
-      );
-      // AsksRepository.subscribe()
-      when(
-        () => mockAsksRepository.subscribe(any(), any())
-      ).thenAnswer(
-        (_) async => () {}
-      );
-
-      // GardensRepository.unsubscribe()
-      when(
-        () => mockGardensRepository.unsubscribe()
-      ).thenAnswer(
-        (_) async => {}
-      );
-      // GardensRepository.subscribe()
-      when(
-        () => mockGardensRepository.subscribe(any())
-      ).thenAnswer(
-        (_) async => () {}
-      );
-
-      // UsersRepository.unsubscribe()
-      when(
-        () => mockUsersRepository.unsubscribe()
-      ).thenAnswer(
-        (_) async => {}
-      );
-      // UsersRepository.subscribe()
-      when(
-        () => mockUsersRepository.subscribe(any(), any())
-      ).thenAnswer(
-        (_) async => () {}
-      );
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: Builder(
-              builder: (BuildContext context) {
-                return ListedGardenTile(garden: tc.garden);
-              }
-            ),
-          ),
-        ));
-
-      // Check title is rendered; appState.currentGarden is null
-      expect(find.text(tc.garden.name), findsOneWidget);
-      expect(appState.currentGarden, null);
-
-      // Tap on the ListTile
-      await tester.tap(find.byType(ListTile));
-      await tester.pumpAndSettle();
-
-      // Check appState.currentGarden has updated
-      expect(appState.currentGarden, tc.garden);
-    });
-
-    tearDown(() => GetIt.instance.reset());
-
     testWidgets("LandingPageListedGardenTile", (tester) async {
       final tc = TestContext();
 
@@ -209,12 +130,12 @@ void main() {
           GoRoute(
             path: "/test_landing_tile",
             builder: (_, __) => Scaffold(
-            body: Builder(
-              builder: (BuildContext context) {
-                return LandingPageListedGardenTile(garden: tc.garden);
-              }
-            ),
-          )
+              body: Builder(
+                builder: (BuildContext context) {
+                  return LandingPageListedGardenTile(garden: tc.garden);
+                }
+              ),
+            )
           )
         ]
       );


### PR DESCRIPTION
- Add permission group based on UserGardenRole
- Create UnauthorizedPage widget to display when user has insufficient permissions for a page

closes https://github.com/Ecanus/plural/issues/63
closes https://github.com/Ecanus/plural/issues/64
closes https://github.com/Ecanus/plural/issues/66

---

![034](https://github.com/user-attachments/assets/b8012c5f-8cbf-4160-85df-877acbfdc07b)
