### PR TITLE
Feature 127 v0.0.4 button check

### DIFF
--- a/plural_app/lib/src/common_widgets/app_checkbox_list_tile_form_field.dart
+++ b/plural_app/lib/src/common_widgets/app_checkbox_list_tile_form_field.dart
@@ -50,6 +50,7 @@ class _AppCheckboxListTileFormFieldState extends State<AppCheckboxListTileFormFi
       ),
       child: Card(
         color: Theme.of(context).colorScheme.primaryContainer,
+        elevation: AppElevations.e0,
         child: FormField<bool>(
           builder: (_) {
             return CheckboxListTile(

--- a/plural_app/lib/src/features/asks/data/forms.dart
+++ b/plural_app/lib/src/features/asks/data/forms.dart
@@ -83,8 +83,8 @@ Future<void> submitUpdate(
       // Display Success Snackbar
       ScaffoldMessenger.of(context).showSnackBar(snackBar);
 
-      // Close Dialog
-      Navigator.pop(context);
+      // Route to Listed Asks View
+      GetIt.instance<AppDialogViewRouter>().routeToListedAsksView();
     } else {
       // Add errors to corresponding fields
       appForm.setErrors(errorsMap: errorsMap);

--- a/plural_app/lib/src/features/asks/presentation/admin_examine_ask_view.dart
+++ b/plural_app/lib/src/features/asks/presentation/admin_examine_ask_view.dart
@@ -110,7 +110,7 @@ class AdminExamineAskViewHeader extends StatelessWidget {
           gapH35,
           Container(
             constraints: BoxConstraints(maxWidth: AppWidths.w200),
-            child: DeleteAskButton(askID: ask.id)
+            child: DeleteAskButton(askID: ask.id, isAdminPage: true,)
           ),
           gapH20,
           AskTimeLeftText(

--- a/plural_app/lib/src/features/asks/presentation/delete_ask_button.dart
+++ b/plural_app/lib/src/features/asks/presentation/delete_ask_button.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+// Common Widgets
 import 'package:plural_app/src/common_widgets/app_snackbars.dart';
 
 // Constants
@@ -9,6 +12,9 @@ import 'package:plural_app/src/features/asks/data/asks_api.dart';
 
 // Localization
 import 'package:plural_app/src/localization/lang_en.dart';
+
+// Utils
+import 'package:plural_app/src/utils/app_dialog_view_router.dart';
 
 class DeleteAskButton extends StatelessWidget {
   const DeleteAskButton({
@@ -123,7 +129,6 @@ class ConfirmDeleteAskDialog extends StatelessWidget {
                     onPressed: () {
                       // Close confirmation, then close the examine/edit ask view
                       Navigator.pop(context);
-                      Navigator.pop(context);
                       deleteAsk(
                         context,
                         askID,
@@ -138,6 +143,9 @@ class ConfirmDeleteAskDialog extends StatelessWidget {
 
                             // Display Success Snackbar
                             ScaffoldMessenger.of(context).showSnackBar(snackBar);
+
+                            // Route to Listed Asks View
+                            GetIt.instance<AppDialogViewRouter>().routeToListedAsksView();
                           }
                         });
                     },

--- a/plural_app/lib/src/features/asks/presentation/delete_ask_button.dart
+++ b/plural_app/lib/src/features/asks/presentation/delete_ask_button.dart
@@ -127,8 +127,9 @@ class ConfirmDeleteAskDialog extends StatelessWidget {
                   constraints: BoxConstraints(minHeight: AppHeights.h40),
                   child: FilledButton(
                     onPressed: () {
-                      // Close confirmation, then close the examine/edit ask view
+                      // Close confirmation
                       Navigator.pop(context);
+
                       deleteAsk(
                         context,
                         askID,
@@ -144,8 +145,12 @@ class ConfirmDeleteAskDialog extends StatelessWidget {
                             // Display Success Snackbar
                             ScaffoldMessenger.of(context).showSnackBar(snackBar);
 
-                            // Route to Listed Asks View
-                            GetIt.instance<AppDialogViewRouter>().routeToListedAsksView();
+                            if (isAdminPage) {
+                              Navigator.pop(context);
+                            } else {
+                              // Route to Listed Asks View
+                              GetIt.instance<AppDialogViewRouter>().routeToListedAsksView();
+                            }
                           }
                         });
                     },

--- a/plural_app/lib/src/features/asks/presentation/edit_ask_view.dart
+++ b/plural_app/lib/src/features/asks/presentation/edit_ask_view.dart
@@ -320,7 +320,7 @@ class IsTargetMetLabel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = isTargetMet ?
-      AppThemes.positiveColor
+      Theme.of(context).colorScheme.primary
       : Theme.of(context).colorScheme.onPrimaryFixed;
 
     return Row(

--- a/plural_app/lib/src/features/asks/presentation/sponsored_asks_view.dart
+++ b/plural_app/lib/src/features/asks/presentation/sponsored_asks_view.dart
@@ -31,10 +31,12 @@ class SponsoredAsksView extends StatelessWidget {
     return Column(
       children: [
         Expanded(
-          child: ListView(
-            padding: const EdgeInsets.all(AppPaddings.p35),
-            children: sponsoredAskTiles,
-          ),
+          child: sponsoredAskTiles.isEmpty ?
+            EmptySponsoredAsksViewMessage() :
+            ListView(
+              padding: const EdgeInsets.all(AppPaddings.p35),
+              children: sponsoredAskTiles,
+            ),
         ),
         AppDialogFooterBuffer(
           buttons: [
@@ -60,6 +62,28 @@ class SponsoredAsksView extends StatelessWidget {
           title: AppDialogFooterText.sponsoredAsks
         )
       ],
+    );
+  }
+}
+
+class EmptySponsoredAsksViewMessage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            AskViewText.emptySponsoredAsksView,
+            style: Theme.of(context).textTheme.headlineSmall
+          ),
+          gapH25,
+          Text(
+            AskViewText.emptySponsoredAsksViewSubtitle,
+            style: Theme.of(context).textTheme.bodyMedium
+          ),
+        ],
+      ),
     );
   }
 }

--- a/plural_app/lib/src/features/authentication/data/auth_api.dart
+++ b/plural_app/lib/src/features/authentication/data/auth_api.dart
@@ -467,6 +467,7 @@ Future<(bool, Map)> signup(
       body: {
         UserSettingsField.defaultCurrency: "",
         UserSettingsField.defaultInstructions: "",
+        UserSettingsField.gardenTimelineDisplayCount: 3,
         UserSettingsField.user: userRecord.id
     });
 

--- a/plural_app/lib/src/features/authentication/domain/app_user_garden_record.dart
+++ b/plural_app/lib/src/features/authentication/domain/app_user_garden_record.dart
@@ -55,6 +55,8 @@ class AppUserGardenRecord {
   final AppUserGardenRole role;
   final AppUser user;
 
+  static DateTime initialDoDocumentReadDate = DateTime(1900, 1, 1);
+
   AppUserGardenRecord.fromJson(
     Map<String, dynamic> json, AppUser recordUser, Garden recordGarden) :
       garden = recordGarden,

--- a/plural_app/lib/src/features/gardens/presentation/examine_do_document_view.dart
+++ b/plural_app/lib/src/features/gardens/presentation/examine_do_document_view.dart
@@ -97,6 +97,7 @@ class _DoDocumentReadCheckboxListTileState extends State<DoDocumentReadCheckboxL
         color: Theme.of(context).colorScheme.primaryContainer
       ),
       child: Card(
+        elevation: AppElevations.e0,
         color: Theme.of(context).colorScheme.primaryContainer,
         child: CheckboxListTile(
           title: Text(

--- a/plural_app/lib/src/features/gardens/presentation/landing_page_gardens_tab.dart
+++ b/plural_app/lib/src/features/gardens/presentation/landing_page_gardens_tab.dart
@@ -32,7 +32,8 @@ class LandingPageGardensTab extends StatelessWidget {
             if (snapshot.hasData) {
               return LandingPageGardensList(userGardenRecords: snapshot.data!);
             } else if (snapshot.hasError) {
-              return LandingPageGardensListError(error: snapshot.error);
+              return LandingPageGardensListError(
+                error: snapshot.error, stackTrace: snapshot.stackTrace);
             } else {
               return LandingPageGardensListLoading();
             }
@@ -54,14 +55,14 @@ class LandingPageGardensList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Expanded(
       child: userGardenRecords.isEmpty ?
-      EmptyLandingPageGardensListMessage() :
-      ListView(
-        padding: const EdgeInsets.all(AppPaddings.p35),
-        children: [
-          for (AppUserGardenRecord record in userGardenRecords)
-            LandingPageListedGardenTile(garden: record.garden)
-        ],
-      ),
+        EmptyLandingPageGardensListMessage() :
+        ListView(
+          padding: const EdgeInsets.all(AppPaddings.p35),
+          children: [
+            for (AppUserGardenRecord record in userGardenRecords)
+              LandingPageListedGardenTile(garden: record.garden)
+          ],
+        ),
     );
   }
 }
@@ -90,14 +91,22 @@ class EmptyLandingPageGardensListMessage extends StatelessWidget {
 class LandingPageGardensListError extends StatelessWidget {
   const LandingPageGardensListError({
     this.error,
+    this.stackTrace,
   });
 
   final Object? error;
+  final StackTrace? stackTrace;
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: Center(child: Text("$error")),
+      child: Center(
+        child: ListView(
+          children: [
+            Text("$error \n\n ${stackTrace.toString()}"),
+          ],
+        )
+      ),
     );
   }
 }

--- a/plural_app/lib/src/features/invitations/data/invitations_api.dart
+++ b/plural_app/lib/src/features/invitations/data/invitations_api.dart
@@ -48,6 +48,8 @@ Future<void> acceptInvitationAndCreateUserGardenRecord(
   // Create UserGardenRecord
   await GetIt.instance<UserGardenRecordsRepository>().create(
     body: {
+      UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+        AppUserGardenRecord.initialDoDocumentReadDate),
       UserGardenRecordField.garden: invitation.garden.id,
       UserGardenRecordField.role: AppUserGardenRole.member.name,
       UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,
@@ -308,6 +310,8 @@ Future<void> validateInvitationUUIDAndCreateUserGardenRecord(
     final (_, errorsMap) =
       await GetIt.instance<UserGardenRecordsRepository>().create(
         body: {
+          UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+            AppUserGardenRecord.initialDoDocumentReadDate),
           UserGardenRecordField.garden: recordJson[InvitationField.garden],
           UserGardenRecordField.role: AppUserGardenRole.member.name,
           UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,

--- a/plural_app/lib/src/localization/lang_en.dart
+++ b/plural_app/lib/src/localization/lang_en.dart
@@ -144,6 +144,10 @@ class AskViewText {
   static const emptyListedAsksViewSubtitle = ""
     "Click the '$createAsk' button below to get started.";
 
+  static const emptySponsoredAsksView = "No sponsored Asks found";
+  static const emptySponsoredAsksViewSubtitle = ""
+    "Check the timeline for Asks to sponsor.";
+
   static const goToListedAsks = "Go to My Asks";
   static const goToSponsoredAsks = "Go to Sponsored Asks";
 

--- a/plural_app/lib/src/localization/lang_en.dart
+++ b/plural_app/lib/src/localization/lang_en.dart
@@ -81,7 +81,7 @@ class AdminPageBottomBarText {
 }
 
 class AppText {
-  static const pluralApp = "Plural App";
+  static const pluralApp = "Plural";
 }
 
 class AppDialogFooterText {

--- a/plural_app/pubspec.lock
+++ b/plural_app/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  cupertino_icons:
+    dependency: "direct main"
+    description:
+      name: cupertino_icons
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   english_words:
     dependency: "direct main"
     description:

--- a/plural_app/pubspec.yaml
+++ b/plural_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: plural_app
-description: A web-based mutual aid application.
+description: An open-source mutual aid application.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
@@ -24,6 +24,7 @@ dependencies:
   url_launcher_platform_interface: ^2.3.2
   plugin_platform_interface: ^2.1.8
   uuid: ^4.5.1
+  cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:

--- a/plural_app/test/features/asks/data/asks_api_test.dart
+++ b/plural_app/test/features/asks/data/asks_api_test.dart
@@ -471,7 +471,7 @@ void main() {
         (_) async => getUserRecordModel()
       );
 
-      var asksList = await getAsksByUserID(userID: "");
+      final asksList = await getAsksByUserID(userID: "");
 
       expect(asksList.length, 2);
       expect(asksList.first, isA<Ask>());

--- a/plural_app/test/features/authentication/data/auth_api_test.dart
+++ b/plural_app/test/features/authentication/data/auth_api_test.dart
@@ -1410,6 +1410,7 @@ void main() {
         () => recordService.create(body: {
           UserSettingsField.defaultCurrency: "",
           UserSettingsField.defaultInstructions: "",
+          UserSettingsField.gardenTimelineDisplayCount: 3,
           UserSettingsField.user: user.id,
         })
       ).thenAnswer(
@@ -1436,6 +1437,7 @@ void main() {
       verify(() => recordService.create(body: {
         UserSettingsField.defaultCurrency: "",
         UserSettingsField.defaultInstructions: "",
+        UserSettingsField.gardenTimelineDisplayCount: 3,
         UserSettingsField.user: getUserRecordModel(user: user).id,
       })).called(1);
       verify(() => recordService.requestVerification(body[UserField.email])).called(1);

--- a/plural_app/test/features/authentication/data/forms_test.dart
+++ b/plural_app/test/features/authentication/data/forms_test.dart
@@ -1307,6 +1307,7 @@ void main() {
         () => recordService.create(body: {
           UserSettingsField.defaultCurrency: "",
           UserSettingsField.defaultInstructions: "",
+          UserSettingsField.gardenTimelineDisplayCount: 3,
           UserSettingsField.user: getUserRecordModel(user: user).id,
         })
       ).thenAnswer(
@@ -1359,6 +1360,7 @@ void main() {
       verify(() => recordService.create(body: {
         UserSettingsField.defaultCurrency: "",
         UserSettingsField.defaultInstructions: "",
+        UserSettingsField.gardenTimelineDisplayCount: 3,
         UserSettingsField.user: getUserRecordModel(user: user).id,
       })).called(1);
       verify(() => recordService.requestVerification(email)).called(1);

--- a/plural_app/test/features/invitations/data/invitations_api_test.dart
+++ b/plural_app/test/features/invitations/data/invitations_api_test.dart
@@ -81,6 +81,8 @@ void main() {
       when(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,
@@ -106,6 +108,8 @@ void main() {
       verifyNever(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,
@@ -128,6 +132,8 @@ void main() {
       verify(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,
@@ -1019,6 +1025,8 @@ void main() {
       when(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: user.id,
@@ -1047,6 +1055,8 @@ void main() {
       verifyNever(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: user.id,
@@ -1073,6 +1083,8 @@ void main() {
       verify(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: user.id,
@@ -1084,6 +1096,8 @@ void main() {
       when(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: user.id,

--- a/plural_app/test/features/invitations/presentation/landing_page_invitation_tile_test.dart
+++ b/plural_app/test/features/invitations/presentation/landing_page_invitation_tile_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
+import 'package:intl/intl.dart';
 import 'package:mocktail/mocktail.dart';
 
 // Constants
 import 'package:plural_app/src/constants/fields.dart';
+import 'package:plural_app/src/constants/formats.dart';
 
 // Auth
 import 'package:plural_app/src/features/authentication/data/user_garden_records_repository.dart';
@@ -78,19 +80,24 @@ void main() {
       when(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,
           }
         )
       ).thenAnswer(
-        (_) async => (getUserGardenRecordRecordModel(
-          userGardenRecord: AppUserGardenRecordFactory(
-            garden: openInvitation.garden,
-            role: AppUserGardenRole.member,
-            user: user,
-          )
-        ), {})
+        (_) async => (
+          getUserGardenRecordRecordModel(
+            userGardenRecord: AppUserGardenRecordFactory(
+              garden: openInvitation.garden,
+              role: AppUserGardenRole.member,
+              user: user,
+            )
+          ),
+          {}
+        )
       );
 
       await tester.pumpWidget(
@@ -116,6 +123,8 @@ void main() {
       verifyNever(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,
@@ -135,6 +144,8 @@ void main() {
       verify(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: GetIt.instance<AppState>().currentUserID!,

--- a/plural_app/test/features/invitations/presentation/landing_page_invitations_tab_test.dart
+++ b/plural_app/test/features/invitations/presentation/landing_page_invitations_tab_test.dart
@@ -170,6 +170,8 @@ void main() {
       when(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: user.id,
@@ -258,6 +260,8 @@ void main() {
       when(
         () => mockUserGardenRecordsRepository.create(
           body: {
+            UserGardenRecordField.doDocumentReadDate: DateFormat(Formats.dateYMMdd).format(
+              AppUserGardenRecord.initialDoDocumentReadDate),
             UserGardenRecordField.garden: openInvitation.garden.id,
             UserGardenRecordField.role: AppUserGardenRole.member.name,
             UserGardenRecordField.user: user.id,


### PR DESCRIPTION
Final changes before deployment of v0.0.4-alpha, per button check:

- Fixed card elevation breaking seamlessness in some clickable checkbox widgets
- Updated reroutes for some actions to go to more convenient views
- Changed colour of notification to match app theme
- Fixed issues with creating a new user (settings.gardenTimelineDisplayCount issue) and creating a new userGardenRecord (doDocumentReadDate issue)
- Updated tests accordingly

closes #127 