### PR TITLE
feat: Description can now be left blank

### DIFF
--- a/plural_app/lib/src/common_functions/form_validators.dart
+++ b/plural_app/lib/src/common_functions/form_validators.dart
@@ -10,6 +10,16 @@ import 'package:plural_app/src/features/authentication/domain/app_user_garden_re
 // Localization
 import 'package:plural_app/src/localization/lang_en.dart';
 
+/// Validates that [value] is valid for a blankable FormField.
+/// i.e. [value] can be an empty string, but cannot be null
+///
+/// Returns null if valid, else returns a String.
+String? validateBlankable(String? value) {
+  if (value == null) return AppFormText.invalidValue;
+
+  return null;
+}
+
 /// Validates that [value] is valid for a CheckboxFormField.
 ///
 /// Returns null if valid, else returns a String.

--- a/plural_app/lib/src/common_widgets/app_text_form_field.dart
+++ b/plural_app/lib/src/common_widgets/app_text_form_field.dart
@@ -79,10 +79,18 @@ class _AppTextFormFieldState extends State<AppTextFormField> {
     var formFieldTypeName = widget.formFieldType.name;
     var textFieldTypeName = widget.textFieldType.name;
 
-    if (formFieldTypeName == "text" && textFieldTypeName == "text") {
-      return validateText;
-    } else if (formFieldTypeName == "digitsOnly" && textFieldTypeName == "digitsOnly") {
-      return validateDigitsOnly;
+    if (
+      formFieldTypeName == FormFieldType.text.name &&
+      textFieldTypeName == TextFieldType.text.name) {
+        return validateText;
+    } else if (
+      formFieldTypeName == FormFieldType.digitsOnly.name &&
+      textFieldTypeName == TextFieldType.digitsOnly.name) {
+        return validateDigitsOnly;
+    } else if (
+      formFieldTypeName == FormFieldType.blankable.name &&
+      textFieldTypeName == TextFieldType.text.name) {
+        return validateBlankable;
     } else {
       return validateText;
     }

--- a/plural_app/lib/src/features/asks/data/asks_api.dart
+++ b/plural_app/lib/src/features/asks/data/asks_api.dart
@@ -49,9 +49,7 @@ Future<void> addSponsor(String askID, String userID) async {
   );
 }
 
-/// Checks if [boon] is strictly less than [targetSum].
-///
-/// Else, throws a [ClientException]
+/// Throws a [ClientException] if [boon] is not strictly less than [targetSum].
 void checkBoonCeiling(int boon, int targetSum) {
   if (boon >= targetSum) {
     Map<String, dynamic> response = {

--- a/plural_app/lib/src/features/asks/data/asks_repository.dart
+++ b/plural_app/lib/src/features/asks/data/asks_repository.dart
@@ -51,9 +51,16 @@ class AsksRepository implements Repository {
   }) async {
     try {
       final boon = body[AskField.boon];
+      final currency = body[AskField.currency];
+      String description = body[AskField.description];
       final targetSum = body[AskField.targetSum];
 
+      // Validate boon < targetSum
       checkBoonCeiling(boon, targetSum);
+
+      // If description == "", set description to targetSum
+      body[AskField.description] = description.isEmpty ?
+        "$targetSum $currency" : description;
 
       final record = await pb.collection(_collection).create(body: body);
       return (record, {});

--- a/plural_app/lib/src/features/asks/presentation/create_ask_view.dart
+++ b/plural_app/lib/src/features/asks/presentation/create_ask_view.dart
@@ -150,6 +150,7 @@ class _CreateAskViewState extends State<CreateAskView> {
                       appForm: _appForm,
                       enabled: widget.hasReadDoDocument,
                       fieldName: AskField.description,
+                      formFieldType: FormFieldType.blankable,
                       label: AskViewText.description,
                       maxLength: AppMaxLengths.max400,
                       maxLines: null,

--- a/plural_app/lib/src/localization/lang_en.dart
+++ b/plural_app/lib/src/localization/lang_en.dart
@@ -123,7 +123,7 @@ class AppDialogFooterBufferText {
 }
 
 class AskViewText {
-  static const askTimeLeftBrace = "—";
+  static const askTimeLeftBrace = "✿";
 
   static const boon = "Boon";
 

--- a/plural_app/lib/src/utils/app_form.dart
+++ b/plural_app/lib/src/utils/app_form.dart
@@ -5,6 +5,7 @@ import 'package:plural_app/src/constants/formats.dart';
 
 // Keep naming consistent with TextFieldType, where possible
 enum FormFieldType {
+  blankable, // can be an empty string, but cannot be null
   currency,
   datetimeNow,
   digitsOnly,
@@ -99,6 +100,8 @@ class AppForm {
     dynamic newValue;
 
     switch (formFieldType) {
+      case FormFieldType.blankable:
+        newValue = value.toString().trim();
       case FormFieldType.currency:
         newValue = value.toString().trim().toUpperCase();
       case FormFieldType.datetimeNow:

--- a/plural_app/test/common_functions/form_validators_test.dart
+++ b/plural_app/test/common_functions/form_validators_test.dart
@@ -16,6 +16,13 @@ import 'package:plural_app/src/localization/lang_en.dart';
 
 void main() {
   group("Form validators test", () {
+    test("validateBlankable", () {
+      expect(validateBlankable(null), AppFormText.invalidValue);
+
+      expect(validateBlankable(""), null);
+      expect(validateBlankable("value"), null);
+    });
+
     test("validateCheckboxFormField", () {
       expect(validateCheckboxFormField(null), AppFormText.invalidValue);
 

--- a/plural_app/test/features/asks/data/asks_repository_test.dart
+++ b/plural_app/test/features/asks/data/asks_repository_test.dart
@@ -66,7 +66,7 @@ void main() {
       final body = {
         AskField.boon: 0,
         AskField.currency: "",
-        AskField.description: "",
+        AskField.description: "description",
         AskField.deadlineDate: "",
         AskField.instructions: "",
         AskField.targetSum: 10,
@@ -86,7 +86,7 @@ void main() {
 
       // RecordService.create(), No Exception
       when(
-        () => recordService.create(body: any(named: "body"))
+        () => recordService.create(body: body)
       ).thenAnswer(
         (_) async => getAskRecordModel()
       );
@@ -99,6 +99,8 @@ void main() {
       expect(record1, isNotNull);
       expect(errorsMap1.isEmpty, true);
 
+
+
       // boon >= targetSum. Check errors map is not empty
       body[AskField.boon] = 5;
       body[AskField.targetSum] = 5;
@@ -109,7 +111,7 @@ void main() {
 
       // RecordService.create() Raise Exception
       when(
-        () => recordService.create(body: any(named: "body"))
+        () => recordService.create(body: body)
       ).thenThrow(
         ClientExceptionFactory(
           exceptionMessage: "Error with ${AskField.boon}",
@@ -124,6 +126,41 @@ void main() {
       var (record3, errorsMap3) = await asksRepository.create(body: body);
       expect(record3, null);
       expect(errorsMap3.isEmpty, false);
+    });
+
+    test("create empty description", () async {
+      final body = {
+        AskField.boon: 0,
+        AskField.currency: "",
+        AskField.description: "",
+        AskField.deadlineDate: "",
+        AskField.instructions: "",
+        AskField.targetSum: 10,
+        AskField.type: "",
+      };
+
+      final pb = MockPocketBase();
+      final recordService = MockRecordService();
+      final asksRepository = AsksRepository(pb: pb);
+
+      // pb.collection()
+      when(
+        () => pb.collection(Collection.asks)
+      ).thenAnswer(
+        (_) => recordService as RecordService
+      );
+
+      // RecordService.create()
+      when(
+        () => recordService.create(body: body)
+      ).thenAnswer(
+        (_) async => getAskRecordModel()
+      );
+
+      await asksRepository.create(body: body);
+
+      // Value for description gets changed because it was an empty string
+      expect(body[AskField.description], "${body[AskField.targetSum]} ${body[AskField.currency]}");
     });
 
     test("delete", () async {


### PR DESCRIPTION
When creating an Ask, description can now be left blank. A generated description value will be put in the field.

closes https://github.com/Ecanus/plural/issues/135