### PR TITLE
fix: admin page uses responsive ui

### DIFF
--- a/plural_app/lib/src/common_functions/app_responsiveness.dart
+++ b/plural_app/lib/src/common_functions/app_responsiveness.dart
@@ -7,6 +7,9 @@ import 'package:plural_app/src/constants/app_sizes.dart';
 import 'package:plural_app/src/localization/lang_en.dart';
 
 class ResponsiveUiKeys {
+  // AdminListedInvitationTile
+  static const adminListedInvitationTileDeleteInvitationText = "adminListedInvitationTileDeleteInvitationText";
+  static const adminListedInvitationTileFontSize = "adminListedInvitationTileFontSize";
   // AppDialogFooter
   static const appDialogFooterBorderRadiusBottom = "appDialogFooterBorderRadiusBottom";
   static const appDialogFooterFontSize = "appDialogFooterFontSize";
@@ -34,6 +37,11 @@ class ResponsiveUiKeys {
 /// Map of responsive values used throughout the app.
 /// First value is for small screens. Second value is for all other screen sizes.
 Map<dynamic, dynamic> responsiveUiValuesMap = {
+  // AdminListedInvitationTile
+  ResponsiveUiKeys.adminListedInvitationTileDeleteInvitationText:
+    (AdminInvitationViewText.deleteInvitationShorthand, AdminInvitationViewText.deleteInvitation),
+  ResponsiveUiKeys.adminListedInvitationTileFontSize:
+    (AppFontSizes.s12, null),
   // AppDialogFooter
   ResponsiveUiKeys.appDialogFooterBorderRadiusBottom:
     (Radius.zero, Radius.circular(AppBorderRadii.r15)),

--- a/plural_app/lib/src/features/authentication/data/auth_api.dart
+++ b/plural_app/lib/src/features/authentication/data/auth_api.dart
@@ -557,7 +557,7 @@ Future<void> updateCurrentUserGardenRecordDoDocumentReadDate() async {
     id: GetIt.instance<AppState>().currentUserGardenRecord!.id,
     body: {
       UserGardenRecordField.doDocumentReadDate:
-        DateFormat(Formats.dateYMMddHHm).format(DateTime.now())
+        DateFormat(Formats.dateYMMddHHms).format(DateTime.now())
     }
   );
 }

--- a/plural_app/lib/src/features/authentication/presentation/expel_user_button.dart
+++ b/plural_app/lib/src/features/authentication/presentation/expel_user_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
 // Common Widgets
+import 'package:plural_app/src/common_widgets/app_close_confirm_dialog_button.dart';
 import 'package:plural_app/src/common_widgets/app_snackbars.dart';
 
 // Constants
@@ -114,25 +115,7 @@ class ConfirmExpelUserDialog extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
-                Container(
-                  constraints: BoxConstraints(minHeight: AppHeights.h40),
-                  child: OutlinedButton(
-                    onPressed: () => Navigator.pop(context),
-                    style: ButtonStyle(
-                      shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(AppBorderRadii.r5)
-                        )
-                      ),
-                    ),
-                    child: Text(
-                      AdminListedUsersViewText.cancelConfirmExpelUser,
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.onSecondary,
-                      ),
-                    ),
-                  ),
-                ),
+                AppCloseConfirmDialogButton(),
                 gapW15,
                 Container(
                   constraints: BoxConstraints(minHeight: AppHeights.h40),

--- a/plural_app/lib/src/features/invitations/presentation/admin_listed_invitation_tile.dart
+++ b/plural_app/lib/src/features/invitations/presentation/admin_listed_invitation_tile.dart
@@ -2,7 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:intl/intl.dart';
 
+// Common Functions
+import 'package:plural_app/src/common_functions/app_responsiveness.dart';
+
 // Common Widgets
+import 'package:plural_app/src/common_widgets/app_close_confirm_dialog_button.dart';
 import 'package:plural_app/src/common_widgets/app_snackbars.dart';
 
 // Constants
@@ -37,6 +41,8 @@ class AdminListedInvitationTile extends StatelessWidget {
           invitation.uuid ?? invitation.invitee?.username
           ?? AdminInvitationViewText.invalidInvitation,
           style: TextStyle(
+            fontSize: getResponsiveUiValue(
+              context, ResponsiveUiKeys.adminListedInvitationTileFontSize),
             fontWeight: FontWeight.w500
           ),
         ),
@@ -45,6 +51,8 @@ class AdminListedInvitationTile extends StatelessWidget {
           "${AdminInvitationViewText.expires} "
           "${DateFormat(Formats.dateYMMdd).format(invitation.expiryDate)}",
           style: TextStyle(
+            fontSize: getResponsiveUiValue(
+              context, ResponsiveUiKeys.adminListedInvitationTileFontSize),
             fontStyle: FontStyle.italic
           ),
         ),
@@ -76,7 +84,7 @@ class AdminListedInvitationTile extends StatelessWidget {
                 Icons.delete,
                 color: Theme.of(context).colorScheme.error,
               ),
-              onPressed: () => showConfirmExpireInvitationDialog(context, invitation.id),
+              onPressed: () => showConfirmDeleteInvitationDialog(context, invitation.id),
               tooltip: AdminInvitationViewText.deleteInvitation,
             ),
           ],
@@ -86,20 +94,20 @@ class AdminListedInvitationTile extends StatelessWidget {
   }
 }
 
-Future<void> showConfirmExpireInvitationDialog(
+Future<void> showConfirmDeleteInvitationDialog(
   BuildContext context,
   String invitationID,
 ) async {
   await showDialog(
     context: context,
     builder: (BuildContext context) {
-      return ConfirmExpireInvitationDialog(invitationID: invitationID);
+      return ConfirmDeleteInvitationDialog(invitationID: invitationID);
     }
   );
 }
 
-class ConfirmExpireInvitationDialog extends StatelessWidget {
-  const ConfirmExpireInvitationDialog({
+class ConfirmDeleteInvitationDialog extends StatelessWidget {
+  const ConfirmDeleteInvitationDialog({
     required this.invitationID,
   });
 
@@ -136,25 +144,7 @@ class ConfirmExpireInvitationDialog extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Container(
-                  constraints: BoxConstraints(minHeight: AppHeights.h40),
-                  child: OutlinedButton(
-                    onPressed: () => Navigator.pop(context),
-                    style: ButtonStyle(
-                      shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-                        RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(AppBorderRadii.r5)
-                        )
-                      ),
-                    ),
-                    child: Text(
-                      AdminInvitationViewText.cancelConfirmDeleteInvitation,
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.onSecondary
-                      )
-                    ),
-                  )
-                ),
+                AppCloseConfirmDialogButton(),
                 gapW15,
                 Container(
                   constraints: BoxConstraints(minHeight: AppHeights.h40),
@@ -188,7 +178,12 @@ class ConfirmExpireInvitationDialog extends StatelessWidget {
                         )
                       ),
                     ),
-                    child: const Text(AdminInvitationViewText.deleteInvitation)
+                    child: Text(
+                      getResponsiveUiValue(
+                        context,
+                        ResponsiveUiKeys.adminListedInvitationTileDeleteInvitationText
+                      )
+                    )
                   )
                 ),
               ],

--- a/plural_app/lib/src/localization/lang_en.dart
+++ b/plural_app/lib/src/localization/lang_en.dart
@@ -1,5 +1,4 @@
 class AdminInvitationViewText {
-  static const cancelConfirmDeleteInvitation = "Cancel";
   static const confirmDeleteInvitation = "Delete Invitation?";
   static const copyCode = "Copy code";
   static const createInvitation = "Create Invitation";
@@ -10,6 +9,7 @@ class AdminInvitationViewText {
     "3) An Invitation to this user is not already active";
 
   static const deleteInvitation = "Delete Invitation";
+  static const deleteInvitationShorthand = "Delete";
 
   static const emptyAdminListedInvitationsViewOpen = ""
     "No active open Invitations found";
@@ -47,7 +47,6 @@ class AdminCurrentGardenSettingsViewText {
 class AdminListedUsersViewText {
   static const adminHeading = "Administrators";
 
-  static const cancelConfirmExpelUser = "Cancel";
   static const confirmExpelUser = "Expel User?";
   static const confirmExpelUserSubtitle = ""
     "Expelling this user will remove them from the Garden, and they will need a new "
@@ -87,7 +86,7 @@ class AppText {
 class AppDialogFooterText {
   static const adminCreateInvitation = "Create Invitation";
   static const adminEditUser = "Edit User";
-  static const adminGardenSettings = "Garden Settings";
+  static const adminGardenSettings = "Garden";
   static const adminListedInvitations = "Active Invitations";
   static const adminListedUsers = "Users";
   static const adminOptionsView = "Options";

--- a/plural_app/test/features/authentication/data/auth_api_test.dart
+++ b/plural_app/test/features/authentication/data/auth_api_test.dart
@@ -1971,7 +1971,7 @@ void main() {
           id: userGardenRecord.id,
           body: {
             UserGardenRecordField.doDocumentReadDate:
-              DateFormat(Formats.dateYMMddHHm).format(now)
+              DateFormat(Formats.dateYMMddHHms).format(now)
           }
         )
       ).thenAnswer(
@@ -1983,7 +1983,7 @@ void main() {
           id: userGardenRecord.id,
           body: {
             UserGardenRecordField.doDocumentReadDate:
-              DateFormat(Formats.dateYMMddHHm).format(now)
+              DateFormat(Formats.dateYMMddHHms).format(now)
           }
         )
       );
@@ -1994,7 +1994,7 @@ void main() {
           id: userGardenRecord.id,
           body: {
             UserGardenRecordField.doDocumentReadDate:
-              DateFormat(Formats.dateYMMddHHm).format(now)
+              DateFormat(Formats.dateYMMddHHms).format(now)
           }
         )
       ).called(1);

--- a/plural_app/test/features/authentication/presentation/expel_user_button_test.dart
+++ b/plural_app/test/features/authentication/presentation/expel_user_button_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// Common Widgets
+import 'package:plural_app/src/common_widgets/app_close_confirm_dialog_button.dart';
+
 // Auth
 import 'package:plural_app/src/features/authentication/presentation/expel_user_button.dart';
-
-// Localization
-import 'package:plural_app/src/localization/lang_en.dart';
 
 // Test
 import '../../../test_factories.dart';
@@ -38,7 +38,7 @@ void main() {
       expect(find.byType(ConfirmExpelUserDialog), findsOneWidget);
 
       // Tap cancel button (to close dialog)
-      await tester.tap(find.text(AdminListedUsersViewText.cancelConfirmExpelUser));
+      await tester.tap(find.byType(AppCloseConfirmDialogButton));
       await tester.pumpAndSettle();
 
       // Check Dialog no longer displayed

--- a/plural_app/test/features/gardens/presentation/examine_do_document_view_test.dart
+++ b/plural_app/test/features/gardens/presentation/examine_do_document_view_test.dart
@@ -1,15 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
-import 'package:intl/intl.dart';
 import 'package:mocktail/mocktail.dart';
 
 // Common Widgets
 import 'package:plural_app/src/common_widgets/app_dialog.dart';
-
-// Constants
-import 'package:plural_app/src/constants/fields.dart';
-import 'package:plural_app/src/constants/formats.dart';
 
 // Auth
 import 'package:plural_app/src/features/authentication/data/user_garden_records_repository.dart';
@@ -59,10 +54,7 @@ void main() {
       when(
         () => mockUserGardenRecordsRepository.update(
           id: userGardenRecord.id,
-          body: {
-            UserGardenRecordField.doDocumentReadDate:
-              DateFormat(Formats.dateYMMddHHm).format(now)
-          }
+          body: any(named: "body") // must use any() because DateTime.now() is called internally
         )
       ).thenAnswer(
         (_) async => (

--- a/plural_app/test/features/invitations/presentation/admin_listed_invitation_tile_test.dart
+++ b/plural_app/test/features/invitations/presentation/admin_listed_invitation_tile_test.dart
@@ -108,7 +108,7 @@ void main() {
       await tester.tap(find.byIcon(Icons.delete).last);
       await tester.pumpAndSettle();
 
-      expect(find.byType(ConfirmExpireInvitationDialog), findsOneWidget);
+      expect(find.byType(ConfirmDeleteInvitationDialog), findsOneWidget);
 
       // Tap FilledButton to call deleteInvitation()
       await tester.tap(find.byType(FilledButton).last);


### PR DESCRIPTION
Admin Page UI now responds to screen size dynamically.

Closes https://github.com/Ecanus/plural/issues/143

---

<img width="379" height="762" alt="078" src="https://github.com/user-attachments/assets/7a68e408-a014-4f8a-8799-de09d05464bc" />
<img width="376" height="757" alt="079" src="https://github.com/user-attachments/assets/ec56435c-d00c-43ba-bf9a-b8e2b56d9020" />
<img width="378" height="757" alt="080" src="https://github.com/user-attachments/assets/f0b14f4c-77c5-49bc-b0da-448f796eb0d0" />
<img width="378" height="755" alt="082" src="https://github.com/user-attachments/assets/594892e6-498d-4702-a150-42113bc06428" />
<img width="378" height="754" alt="084" src="https://github.com/user-attachments/assets/88994743-5421-4675-895d-ecb58e605abe" />
